### PR TITLE
Use `Point` for `Rect` and tons of refactoring.

### DIFF
--- a/src/button.rs
+++ b/src/button.rs
@@ -14,9 +14,9 @@ pub struct Button {
 }
 
 impl Button {
-    pub fn new(rect: Rect, text: &str) -> Self {
+    pub fn new(text: &str) -> Self {
         Button {
-            rect: rect,
+            rect: Rect::default(),
             text: text.to_string(),
             bg_up: Color::rgb(220, 222, 227),
             bg_down: Color::rgb(203, 205, 210),
@@ -65,7 +65,8 @@ impl Widget for Button {
         let mut x = 0;
         for c in self.text.chars() {
             if x + 8 <= self.rect.width as isize {
-                renderer.char(Point::new(x + self.rect.x, self.rect.y), c, self.fg);
+                let point = self.rect.get_point();
+                renderer.char(Point::new(x + point.x, point.y), c, self.fg);
             }
             x += 8;
         }
@@ -93,11 +94,16 @@ impl Widget for Button {
                 }
 
                 if click {
-                    let click_point = Point::new(point.x - self.rect.x, point.y - self.rect.y);
+                    let rect_point = self.rect.get_point();
+                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
                     self.click(click_point);
                 }
             },
             _ => ()
         }
+    }
+
+    pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
+        self.rect.point = Some(Point {x: x, y: y});
     }
 }

--- a/src/button.rs
+++ b/src/button.rs
@@ -103,6 +103,6 @@ impl Widget for Button {
     }
 
     pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
-        self.rect.point = Some(Point {x: x, y: y});
+        self.rect.point = Some(Point::new(x, y));
     }
 }

--- a/src/button.rs
+++ b/src/button.rs
@@ -66,7 +66,7 @@ impl Widget for Button {
         for c in self.text.chars() {
             if x + 8 <= self.rect.width as isize {
                 let point = self.rect.get_point();
-                renderer.char(Point::new(x + point.x, point.y), c, self.fg);
+                renderer.char(Point::new(x, 0) + point, c, self.fg);
             }
             x += 8;
         }
@@ -94,8 +94,7 @@ impl Widget for Button {
                 }
 
                 if click {
-                    let rect_point = self.rect.get_point();
-                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
+                    let click_point: Point = point - self.rect.get_point();
                     self.click(click_point);
                 }
             },

--- a/src/label.rs
+++ b/src/label.rs
@@ -13,9 +13,9 @@ pub struct Label {
 }
 
 impl Label {
-    pub fn new(rect: Rect, text: &str) -> Self {
+    pub fn new(text: &str) -> Self {
         Label {
-            rect: Cell::new(rect),
+            rect: Cell::new(Rect::default()),
             text: RefCell::new(text.to_string()),
             bg: Color::rgb(237, 233, 227),
             fg: Color::rgb(0, 0, 0),
@@ -61,7 +61,8 @@ impl Widget for Label {
         let text = self.text.borrow();
         for c in text.chars() {
             if x + 8 <= rect.width as isize {
-                renderer.char(Point::new(x + rect.x, rect.y), c, self.fg);
+                let point = rect.get_point();
+                renderer.char(Point::new(x + point.x, point.y), c, self.fg);
             }
             x += 8;
         }
@@ -90,11 +91,18 @@ impl Widget for Label {
                 }
 
                 if click {
-                    let click_point = Point::new(point.x - rect.x, point.y - rect.y);
+                    let rect_point = rect.get_point();
+                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
                     self.click(click_point);
                 }
             },
             _ => ()
         }
+    }
+
+    pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
+        let mut rect = self.rect.get();
+        rect.point = Some(Point {x: x, y: y});
+        self.rect.set(rect);
     }
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -101,7 +101,7 @@ impl Widget for Label {
 
     pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
         let mut rect = self.rect.get();
-        rect.point = Some(Point {x: x, y: y});
+        rect.point = Some(Point::new(x, y));
         self.rect.set(rect);
     }
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -62,7 +62,7 @@ impl Widget for Label {
         for c in text.chars() {
             if x + 8 <= rect.width as isize {
                 let point = rect.get_point();
-                renderer.char(Point::new(x + point.x, point.y), c, self.fg);
+                renderer.char(Point::new(x, 0) + point, c, self.fg);
             }
             x += 8;
         }
@@ -91,8 +91,7 @@ impl Widget for Label {
                 }
 
                 if click {
-                    let rect_point = rect.get_point();
-                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
+                    let click_point: Point = point - rect.get_point();
                     self.click(click_point);
                 }
             },

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -91,8 +91,7 @@ impl Widget for ProgressBar {
                 }
 
                 if click {
-                    let rect_point = self.rect.get_point();
-                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
+                    let click_point: Point = point - self.rect.get_point();
                     self.click(click_point);
                 }
             },

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -16,9 +16,9 @@ pub struct ProgressBar {
 }
 
 impl ProgressBar {
-    pub fn new(rect: Rect, value: isize) -> Self {
+    pub fn new(value: isize) -> Self {
         ProgressBar {
-            rect: rect,
+            rect: Rect::default(),
             value: Cell::new(value),
             minimum: 0,
             maximum: 100,
@@ -60,9 +60,10 @@ impl Click for ProgressBar {
 impl Widget for ProgressBar {
     fn draw(&self, renderer: &mut Renderer) {
         renderer.rect(self.rect, self.bg);
+        let point = self.rect.get_point();
         renderer.rect(Rect::new(
-            self.rect.x,
-            self.rect.y,
+            point.x,
+            point.y,
             ((self.rect.width as isize * max(0, min(self.maximum, self.value.get() - self.minimum)))/max(1, self.maximum - self.minimum)) as usize,
             self.rect.height
         ), self.fg);
@@ -90,11 +91,16 @@ impl Widget for ProgressBar {
                 }
 
                 if click {
-                    let click_point = Point::new(point.x - self.rect.x, point.y - self.rect.y);
+                    let rect_point = self.rect.get_point();
+                    let click_point = Point::new(point.x - rect_point.x, point.y - rect_point.y);
                     self.click(click_point);
                 }
             },
             _ => ()
         }
+    }
+
+    pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
+        self.rect.point = Some(Point {x: x, y: y});
     }
 }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -100,6 +100,6 @@ impl Widget for ProgressBar {
     }
 
     pub fn position(&mut self, x: isize, y: isize) -> &mut Self {
-        self.rect.point = Some(Point {x: x, y: y});
+        self.rect.point = Some(Point::new(x, y));
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,8 +2,11 @@ use super::Point;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Rect {
+    /*
     pub x: isize,
     pub y: isize,
+    */
+    pub point: Option<Point>,
     pub width: usize,
     pub height: usize,
 }
@@ -11,15 +14,22 @@ pub struct Rect {
 impl Rect {
     pub fn new(x: isize, y: isize, width: usize, height: usize) -> Rect {
         Rect {
-            x: x,
-            y: y,
+            point: Some(Point::new(x, y)),
             width: width,
             height: height,
         }
     }
 
     pub fn contains(&self, p: Point) -> bool {
-        p.x >= self.x && p.x < self.x + self.width as isize &&
-        p.y >= self.y && p.y < self.y + self.height as isize
+        if let Some(this) = self.point {
+            p.x >= this.x && p.x < this.x + self.width as isize &&
+            p.y >= this.y && p.y < this.y + self.height as isize
+        }
+
+        false
+    }
+
+    pub fn get_point(&self) -> Point {
+        self.point.unwrap_or(Point::new(0, 0))
     }
 }

--- a/src/sdl2/mod.rs
+++ b/src/sdl2/mod.rs
@@ -36,9 +36,11 @@ impl<'a> Renderer for SdlRenderer<'a> {
     }
 
     fn rect(&mut self, rect: Rect, color: Color) {
-        if let Some(rect) = sdl2::rect::Rect::new(rect.x as i32, rect.y as i32, rect.width as u32, rect.height as u32).unwrap() {
-            self.inner.set_draw_color(sdl2::pixels::Color::RGBA((color.data >> 16) as u8, (color.data >> 8) as u8, color.data as u8, (color.data >> 24) as u8));
-            self.inner.fill_rect(rect);
+        if let Some(rect_point) = rect.point {
+            if let Some(sdl_rect) = sdl2::rect::Rect::new(rect_point.x as i32, rect_point.y as i32, rect.width as u32, rect.height as u32).unwrap() {
+                self.inner.set_draw_color(sdl2::pixels::Color::RGBA((color.data >> 16) as u8, (color.data >> 8) as u8, color.data as u8, (color.data >> 24) as u8));
+                self.inner.fill_rect(sdl_rect);
+            }
         }
     }
 }
@@ -66,7 +68,9 @@ impl Window {
         let video_ctx = ctx.video().unwrap();
         let ttf_context = sdl2_ttf::init().unwrap();
 
-        let mut window = video_ctx.window(title, rect.width as u32, rect.height as u32).position(rect.x as i32, rect.y as i32).opengl().build().unwrap();
+        let point = rect.get_point();
+        let mut window = video_ctx.window(title, rect.width as u32, rect.height as u32).position(point.x as i32, point.y as i32).opengl().build().unwrap();
+        drop(point);
         window.show();
 
         let events = ctx.event_pump().unwrap();

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -5,4 +5,5 @@ use std::any::Any;
 pub trait Widget : Any {
     fn draw(&self, renderer: &mut Renderer);
     fn event(&self, event: Event);
+    fn position(&mut self, x: isize, y: isize) -> &mut Self;
 }


### PR DESCRIPTION
* Use `Point` for the positioning in `Rect`
 * Wrap `Point` with `Option` for defaulting to `None`
* Remove `Rect` arguments in widget constructors
 * Use `Rect::default()` for filling in `rect` fields instead
* Add `Widget::position()` builder method for all widgets
* Add `Rect::get_point()` to make it less repetitive to get a `Point` within `Option`
* Apply necessary fixes for `Point` related warnings

Btw, there are still errors about using the `Widget` trait as an object and stuff about iterators.