### PR TITLE
Cleanup `Enter` for `TextBox`

### DIFF
--- a/src/enter.rs
+++ b/src/enter.rs
@@ -1,4 +1,4 @@
 pub trait Enter {
-    fn trigger_enter(&self) -> bool;
-    fn on_enter<T: Fn(&Self) -> bool + 'static>(mut self, func: T) -> Self;
+    fn trigger_on_enter(&self);
+    fn on_enter<T: Fn(&Self) + 'static>(mut self, func: T) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,8 @@ pub fn example() {
     let text_box = TextBox::new()
         .position(x, y)
         .size(342, 16)
-        .on_enter(move |text_box: &TextBox| -> bool {
+        .on_enter(move |text_box: &TextBox| {
             label.text.set(text_box.text.get());
-            false
         })
         .place(&mut window);
 
@@ -69,7 +68,7 @@ pub fn example() {
         .size(48, text_box.rect.get().height)
         .text("Update")
         .on_click(move |_button: &Button, _point: Point| {
-            text_box.trigger_enter();
+            text_box.trigger_on_enter();
         })
         .place(&mut window);
 


### PR DESCRIPTION
By using the `on_enter()` builder for `TextBox`, it automatically uses the custom callback instead of the default multi-line functionality without the need to return `false`.