### PR TITLE
Add basic menu functionality. Working example in src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use cell::CloneCell;
 pub use color::Color;
 pub use event::Event;
 pub use label::Label;
-pub use menu::Menu;
+pub use menu::{Menu, Action};
 pub use place::Place;
 pub use point::Point;
 pub use progress_bar::ProgressBar;
@@ -40,7 +40,13 @@ pub fn example() {
     let mut window = Window::new(Rect::new(100, 100, 420, 420), "OrbTK");
 
     let x = 10;
-    let mut y = 10;
+    let mut y = 0;
+
+    let mut menu = Menu::new("Menu")
+        .position(x, y)
+        .size(32, 16);
+
+    y += menu.rect.get().height as i32 + 10;
 
     let label = Label::new()
         .position(x, y)
@@ -104,12 +110,41 @@ pub fn example() {
 
     y += multi_line_text_box.rect.get().height as i32 + 10;
 
-    Label::new()
+    let offset_label = Label::new()
         .position(x, y)
         .size(400, 256)
         .text("Test Offset")
         .text_offset(50, 50)
         .place(&mut window);
+
+    {
+        let offset_label_clone = offset_label.clone();
+        menu.add_action(Action::new("Label One")
+            .on_click(move |_action: &Action, _point: Point| {
+                offset_label_clone.text.set("One".to_owned());
+            }));
+    }
+
+    {
+        let offset_label_clone = offset_label.clone();
+        menu.add_action(Action::new("Label Two")
+            .on_click(move |_action: &Action, _point: Point| {
+                offset_label_clone.text.set("Two".to_owned());
+            }));
+    }
+
+    menu.add_separator();
+
+    {
+        let offset_label_clone = offset_label.clone();
+        menu.add_action(Action::new("Reset Label")
+            .on_click(move |_action: &Action, _point: Point| {
+                offset_label_clone.text.set("Text Offset".to_owned());
+            }));
+    }
+
+    // TODO: Don't require this to be placed last to be drawn last
+    menu.place(&mut window);
 
     window.exec();
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -2,38 +2,48 @@ extern crate orbimage;
 
 use self::orbimage::Image;
 
-use super::{CloneCell, Color, Event, Place, Point, Rect, Renderer, Widget};
+use super::{CloneCell, Color, Event, Place, Point, Rect, Renderer, Widget, Window};
 use super::callback::Click;
 use super::cell::CheckSet;
 
 use std::cell::Cell;
 use std::sync::Arc;
 
-#[allow(dead_code)]
 pub struct Menu {
-    rect: Cell<Rect>,
+    pub rect: Cell<Rect>,
     text: CloneCell<String>,
+    bg_up: Color,
+    bg_down: Color,
     fg: Color,
+    text_offset: Point,
     entries: Vec<Box<Entry>>,
     click_callback: Option<Arc<Fn(&Menu, Point)>>,
+    pressed: Cell<bool>,
     activated: Cell<bool>,
 }
 
-#[allow(dead_code)]
 pub struct Action {
     rect: Cell<Rect>,
     text: CloneCell<String>,
     icon: Option<Image>,
     bg_up: Color,
     bg_down: Color,
+    fg: Color,
+    text_offset: Point,
     click_callback: Option<Arc<Fn(&Action, Point)>>,
     pressed: Cell<bool>,
+    hover: Cell<bool>,
 }
 
-pub struct Separator;
+pub struct Separator {
+    rect: Cell<Rect>,
+    bg: Color,
+    fg: Color,
+}
 
-pub trait Entry {
+pub trait Entry: Widget {
     fn text(&mut self) -> String;
+    fn rect(&self) -> &Cell<Rect>;
 }
 
 impl Menu {
@@ -41,32 +51,76 @@ impl Menu {
         Menu {
             rect: Cell::new(Rect::default()),
             text: CloneCell::new(name.to_owned()),
+            bg_up: Color::rgb(220, 222, 227),
+            bg_down: Color::rgb(203, 205, 210),
             fg: Color::rgb(0, 0, 0),
+            text_offset: Point::default(),
             entries: Vec::with_capacity(10),
             click_callback: None,
+            pressed: Cell::new(false),
             activated: Cell::new(false),
         }
     }
 
-    pub fn add_entry<E: 'static + Entry + Place>(mut self, mut entry: E) -> Self {
-        let mut rect = self.rect.get();
-        let entry_text = entry.text();
-        if rect.width < entry_text.len() as u32 {
+    pub fn add_action(&mut self, mut action: Action) {
+        let mut action_rect = self.rect.get();
+        let action_text_width = action.text().len() as u32 * 8;
+        if action_rect.width < action_text_width {
             // TODO: consider the icon width and some padding
-            rect.width = entry_text.len() as u32;
+            action_rect.width = action_text_width;
         }
 
-        if entry_text.is_empty() {
-            // Separator entry goes here
-            entry = entry.size(rect.width, 10);
-            rect.height += 10;
-        } else {
-            entry = entry.size(rect.width, 30);
-            rect.height += 30;
-        }
-        self.entries.push(Box::new(entry));
+        let mut y = action_rect.y + action_rect.height as i32;
+        for entry in self.entries.iter() {
+            let mut entry_rect = entry.rect().get();
+            y += entry_rect.height as i32;
 
-        self.rect.set(rect);
+            if entry_rect.width < action_rect.width {
+                entry_rect.width = action_rect.width;
+                entry.rect().set(entry_rect);
+            } else {
+                action_rect.width = entry_rect.width;
+            }
+        }
+        action_rect.y = y;
+        action.rect().set(action_rect);
+        self.entries.push(Box::new(action));
+    }
+
+    pub fn add_separator(&mut self) {
+        let mut sep_rect = self.rect.get();
+
+        let mut y = sep_rect.y + sep_rect.height as i32;
+        for entry in self.entries.iter() {
+            let entry_rect = entry.rect().get();
+            y += entry_rect.height as i32;
+
+            if entry_rect.width > sep_rect.width {
+                sep_rect.width = entry_rect.width;
+            }
+        }
+        sep_rect.y = y;
+
+        let separator = Separator::new();
+        separator.rect().set(sep_rect);
+        self.entries.push(Box::new(separator));
+    }
+
+    pub fn place(self, window: &mut Window) -> Arc<Self> {
+        let arc = Arc::new(self);
+
+        window.widgets.push(arc.clone());
+
+        arc
+    }
+
+    pub fn text(self, text: &str) -> Self {
+        self.text.set(text.to_owned());
+        self
+    }
+
+    pub fn text_offset(mut self, x: i32, y: i32) -> Self {
+        self.text_offset = Point::new(x, y);
         self
     }
 }
@@ -96,23 +150,81 @@ impl Widget for Menu {
         let rect = self.rect.get();
 
         if self.activated.get() {
-            renderer.rect(rect, self.fg);
+            renderer.rect(rect, self.bg_down);
+        } else {
+            renderer.rect(rect, self.bg_up);
+        }
+
+        let text = self.text.borrow();
+        let mut point = self.text_offset;
+        for c in text.chars() {
+            if c == '\n' {
+                point.x = 0;
+                point.y += 16;
+            } else {
+                if point.x + 8 <= rect.width as i32 && point.y + 16 <= rect.height as i32 {
+                    renderer.char(point + rect.point(), c, self.fg);
+                }
+                point.x += 8;
+            }
+        }
+
+        if self.activated.get() {
+            for entry in self.entries.iter() {
+                entry.draw(renderer, _focused);
+            }
         }
     }
 
     fn event(&self, event: Event, focused: bool, redraw: &mut bool) -> bool {
+        let mut ignore_event = false;
+        if self.activated.get() {
+            for entry in self.entries.iter() {
+                if entry.event(event, focused, redraw) {
+                    ignore_event = true;
+                    self.pressed.set(true);
+                }
+            }
+        }
+
         match event {
             Event::Mouse { point, left_button, .. } => {
-                //let mut click = false;
+                let mut click = false;
 
                 let rect = self.rect.get();
                 if rect.contains(point) {
-                    if left_button && self.activated.check_set(true) {
-                        *redraw = true;
-                    } else if self.activated.check_set(false) {
-                        //click = true;
-                        *redraw = true;
+                    if left_button {
+                        self.pressed.set(!self.pressed.get());
+
+                        if self.activated.check_set(true) {
+                            click = true;
+                            *redraw = true;
+                        }
+                    } else {
+                        if !self.pressed.get() {
+                            if self.activated.check_set(false) {
+                                click = true;
+                                *redraw = true;
+                            }
+                        }
                     }
+                } else {
+                    if !ignore_event {
+                        if left_button {
+                            self.pressed.set(false);
+                        } else {
+                            if !self.pressed.get() {
+                                if self.activated.check_set(false) {
+                                    *redraw = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if click {
+                    let click_point: Point = point - rect.point();
+                    self.emit_click(click_point);
                 }
             }
             _ => (),
@@ -129,8 +241,11 @@ impl Action {
             icon: None,
             bg_up: Color::rgb(220, 222, 227),
             bg_down: Color::rgb(203, 205, 210),
+            fg: Color::rgb(0, 0, 0),
+            text_offset: Point::default(),
             click_callback: None,
             pressed: Cell::new(false),
+            hover: Cell::new(false),
         }
     }
 
@@ -138,57 +253,84 @@ impl Action {
         self.icon = Some(icon);
         self
     }
-}
 
-impl Place for Action {
-    fn rect(&self) -> &Cell<Rect> {
-        &self.rect
+    pub fn text_offset(mut self, x: i32, y: i32) -> Self {
+        self.text_offset = Point::new(x, y);
+        self
     }
 }
 
-/*
+impl Click for Action {
+    fn emit_click(&self, point: Point) {
+        if let Some(ref click_callback) = self.click_callback {
+            click_callback(self, point);
+        }
+    }
+
+    fn on_click<T: Fn(&Self, Point) + 'static>(mut self, func: T) -> Self {
+        self.click_callback = Some(Arc::new(func));
+
+        self
+    }
+}
+
 impl Widget for Action {
     fn draw(&self, renderer: &mut Renderer, _focused: bool) {
         let rect = self.rect.get();
 
-        if self.pressed.get() {
+        if self.hover.get() {
             renderer.rect(rect, self.bg_down);
         } else {
             renderer.rect(rect, self.bg_up);
         }
 
-        //let text = self.text.borrow();
-
-        //let mut x = 0;
-        //let mut y = 0;
-        //for c in text.chars() {
-        //    if c == '\n' {
-        //        x = 0;
-        //        y += 16;
-        //    } else {
-        //        if x + 8 <= rect.width as i32 && y + 16 <= rect.height as i32 {
-        //            renderer.char(Point::new(x, y) + rect.point(), c, self.fg);
-        //        }
-        //        x += 8;
-        //    }
-        //}
+        let text = self.text.borrow();
+        let mut point = self.text_offset;
+        for c in text.chars() {
+            if c == '\n' {
+                point.x = 0;
+                point.y += 16;
+            } else {
+                if point.x + 8 <= rect.width as i32 && point.y + 16 <= rect.height as i32 {
+                    renderer.char(point + rect.point(), c, self.fg);
+                }
+                point.x += 8;
+            }
+        }
     }
 
-    fn event(&self, event: Event, focused: bool, redraw: &mut bool) -> bool {
+    fn event(&self, event: Event, _focused: bool, redraw: &mut bool) -> bool {
         match event {
             Event::Mouse { point, left_button, .. } => {
                 let mut click = false;
                 let rect = self.rect.get();
 
                 if rect.contains(point) {
-                    if left_button && self.pressed.check_set(true) {
-                        *redraw = true;
-                    } else if self.pressed.check_set(false) {
-                        click = true;
+                    if self.hover.check_set(true) {
                         *redraw = true;
                     }
-                } else if !left_button && self.pressed.check_set(false) {
-                    *redraw = true;
+
+                    if left_button {
+                        if self.pressed.check_set(true) {
+                            *redraw = true;
+                        }
+                    } else {
+                        if self.pressed.check_set(false) {
+                            click = true;
+                            self.hover.set(false);
+                            *redraw = true;
+                        }
+                    }
+                } else {
+                    if self.hover.check_set(false) {
+                        *redraw = true;
+                    }
+
+                    if !left_button {
+                        if self.pressed.check_set(false) {
+                            *redraw = true;
+                        }
+                    }
                 }
 
                 if click {
@@ -196,14 +338,10 @@ impl Widget for Action {
                     self.emit_click(click_point);
                 }
             }
+            _ => (),
         }
-    }
-}
-*/
 
-impl Entry for Menu {
-    fn text(&mut self) -> String {
-        self.text.get()
+        false
     }
 }
 
@@ -211,10 +349,54 @@ impl Entry for Action {
     fn text(&mut self) -> String {
         self.text.get()
     }
+
+    fn rect(&self) -> &Cell<Rect> {
+        &self.rect
+    }
+}
+
+impl Separator {
+    pub fn new() -> Self {
+        Separator {
+            rect: Cell::new(Rect::default()),
+            bg: Color::rgb(220, 222, 227),
+            fg: Color::rgb(0, 0, 0),
+        }
+    }
+}
+
+impl Widget for Separator {
+    fn draw(&self, renderer: &mut Renderer, _focused: bool) {
+        let rect = self.rect.get();
+        renderer.rect(rect, self.bg);
+
+        let line_y = rect.y + rect.height as i32 / 2;
+        let start = Point::new(rect.x, line_y);
+        let end = Point::new(rect.x + rect.width as i32, line_y);
+        renderer.line(start, end, self.fg);
+    }
+
+    fn event(&self, event: Event, _focused: bool, _redraw: &mut bool) -> bool {
+        let mut ignore_event = false;
+        match event {
+            Event::Mouse { point, .. } => {
+                let rect = self.rect.get();
+                if rect.contains(point) {
+                    ignore_event = true;
+                }
+            }
+            _ => (),
+        }
+        ignore_event
+    }
 }
 
 impl Entry for Separator {
     fn text(&mut self) -> String {
         String::new()
+    }
+
+    fn rect(&self) -> &Cell<Rect> {
+        &self.rect
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,4 +4,5 @@ pub trait Renderer {
     fn clear(&mut self, color: Color);
     fn char(&mut self, pos: Point, c: char, color: Color);
     fn rect(&mut self, rect: Rect, color: Color);
+    fn line(&mut self, start: Point, end: Point, color: Color);
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -36,6 +36,14 @@ impl<'a> Renderer for WindowRenderer<'a> {
                         rect.height,
                         orbclient::Color { data: color.data });
     }
+
+    fn line(&mut self, start: Point, end: Point, color: Color) {
+        self.inner.line(start.x,
+                        start.y,
+                        end.x,
+                        end.y,
+                        orbclient::Color { data: color.data });
+    }
 }
 
 impl<'a> Drop for WindowRenderer<'a> {


### PR DESCRIPTION
**Problem:** User interface is missing menus.

**Solution:** Add menu support in orbtk.

**Changes introduced by this pull request:**
- menu.rs contains the majority of the changes. I attempted to extrapolate from existing work and create a functional and intuitive foundation for menus.
- lib.rs (the example program) contains a working example of a menu.
- lines in renderer.rs and window.rs are for the separator.

**Drawbacks:** Currently, the menu must be added to the window last so that it is drawn on top of the other elements.

**TODOs:** In order to address the above drawback, I believe the next step would be implementing a dedicated menu bar which is always rendered last and can have menus added to it (rather than directly placed on the window).

**State:** Ready. However, I would recommend against adding menus to the other existing applications until further work is complete as the API is likely to change.

**Other:** None.