### PR TITLE
Add input event filtering for textboxes.

### DIFF
--- a/examples/filtered.rs
+++ b/examples/filtered.rs
@@ -1,0 +1,46 @@
+extern crate orbtk;
+
+use orbtk::{Window, TextBox, Rect, Placeable, Label};
+use orbtk::callback::EventFilter;
+use orbtk::Event;
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+fn main() {
+    let window = Window::new(Rect::new(100, 100, 420, 420), "Filtered Textbox");
+
+    let label = Label::new().text("Field below will ignore all 'e' chars.")
+                            .position(10, 10).size(400, 16).place(&window);
+
+    let text_field = TextBox::new().position(10, 32).size(400, 16).event_filter(|widget, event, focused, redraw| {
+        match event {
+            Event::Text { c: 'e' } => {
+                None
+            }
+            _ => {
+                Some(event)
+            }
+        }
+    }).place(&window);
+
+    let label = Label::new().text("Field below will only accept numbers \n(as defined by unicode)")
+                            .position(10, 32+16+6).size(400, 32).place(&window);
+                            
+    let text_field = TextBox::new().position(10, 32+32+12+16).size(400, 16).event_filter(|widget, event, focused, redraw| {
+        match event {
+            Event::Text { c } => {
+                if c.is_numeric() {
+                    Some(event)
+                } else {
+                    None
+                }
+            }
+            _ => {
+                Some(event)
+            }
+        }
+    }).place(&window);
+
+    window.exec();
+}

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,4 +1,5 @@
 use super::Point;
+use super::Event;
 
 pub trait Click {
     fn emit_click(&self, point: Point);
@@ -8,4 +9,9 @@ pub trait Click {
 pub trait Enter {
     fn emit_enter(&self);
     fn on_enter<T: Fn(&Self) + 'static>(self, func: T) -> Self;
+}
+
+pub trait EventFilter {
+    fn handle_event(&self, event: Event, focused: &mut bool, redraw: &mut bool) -> Option<Event>;
+    fn event_filter<T: Fn(&Self, Event, &mut bool, &mut bool) -> Option<Event> + 'static>(self, func: T) -> Self;
 }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1,5 +1,5 @@
 use super::{CloneCell, Color, Event, Placeable, Point, Rect, Renderer, Widget, WidgetCore};
-use super::callback::{Click, Enter};
+use super::callback::{Click, Enter, EventFilter};
 use super::cell::CheckSet;
 
 use std::cell::{Cell, RefCell};
@@ -27,6 +27,15 @@ pub struct TextBox {
     pub grab_focus: Cell<bool>,
     pub on_click: RefCell<Option<Arc<Fn(&TextBox, Point)>>>,
     pub on_enter: RefCell<Option<Arc<Fn(&TextBox)>>>,
+    /// If event_filter is defined, all of the events will go trough it
+    /// Instead of the default behavior. This allows defining fields that
+    /// ex. will only accept numbers and ignore all else, or add some 
+    /// special behavior for some keys. 
+    ///
+    /// The closure should return None if the event was manually handled,
+    /// or should return the event it received if it wants the default
+    /// handler deal with it.
+    pub event_filter: RefCell<Option<Arc<Fn(&TextBox, Event, &mut bool, &mut bool) -> Option<Event>>>>,
     pressed: Cell<bool>,
 }
 
@@ -39,6 +48,7 @@ impl TextBox {
             fg_cursor: Color::gray(),
             on_click: RefCell::new(None),
             on_enter: RefCell::new(None),
+            event_filter: RefCell::new(None),
             grab_focus: Cell::new(false),
             pressed: Cell::new(false),
         }
@@ -86,6 +96,22 @@ impl Enter for TextBox {
 }
 
 impl Placeable for TextBox {}
+
+impl EventFilter for TextBox {
+    fn handle_event(&self, event: Event, focused: &mut bool, redraw: &mut bool) -> Option<Event> {
+        if let Some(ref event_filter) = *self.event_filter.borrow() {
+            event_filter(self, event, focused, redraw)
+        } else {
+            Some(event)
+        }
+    }
+
+    fn event_filter<T: Fn(&Self, Event, &mut bool, &mut bool) -> Option<Event> + 'static>(self, func: T) -> Self {
+        *self.event_filter.borrow_mut() = Some(Arc::new(func));
+
+        self
+    }
+}
 
 impl Widget for TextBox {
     fn rect(&self) -> &Cell<Rect> {
@@ -137,268 +163,270 @@ impl Widget for TextBox {
     }
 
     fn event(&self, event: Event, mut focused: bool, redraw: &mut bool) -> bool {
-        match event {
-            Event::Mouse { point, left_button, .. } => {
-                let mut click = false;
+        // If the event wasn't handled by the custom handler.
+        if let Some(event) = self.handle_event(event, &mut focused, redraw) {   
+            match event {
+                Event::Mouse { point, left_button, .. } => {
+                    let mut click = false;
 
-                let rect = self.core.rect.get();
-                if rect.contains(point) {
-                    if left_button {
-                        if self.pressed.check_set(true) {
-                            *redraw = true;
+                    let rect = self.core.rect.get();
+                    if rect.contains(point) {
+                        if left_button {
+                            if self.pressed.check_set(true) {
+                                *redraw = true;
+                            }
+                        } else {
+                            if self.pressed.check_set(false) {
+                                click = true;
+                                *redraw = true;
+                            }
                         }
                     } else {
-                        if self.pressed.check_set(false) {
-                            click = true;
-                            *redraw = true;
+                        if ! left_button {
+                            if self.pressed.check_set(false) {
+                                *redraw = true;
+                            }
                         }
                     }
-                } else {
-                    if ! left_button {
-                        if self.pressed.check_set(false) {
-                            *redraw = true;
-                        }
-                    }
-                }
 
-                if click {
-                    focused = true;
+                    if click {
+                        focused = true;
 
-                    let click_point: Point = point - rect.point();
-                    {
-                        let text = self.text.borrow();
+                        let click_point: Point = point - rect.point();
+                        {
+                            let text = self.text.borrow();
 
-                        let mut new_text_i = None;
+                            let mut new_text_i = None;
 
-                        let mut x = 0;
-                        let mut y = 0;
-                        for (i, c) in text.char_indices() {
-                            if c == '\n' {
-                                if x + 8 <= rect.width as i32 && click_point.x >= x &&
-                                   y + 16 <= rect.height as i32 &&
-                                   click_point.y >= y &&
-                                   click_point.y < y + 16 {
-                                    new_text_i = Some(i);
-                                    break;
+                            let mut x = 0;
+                            let mut y = 0;
+                            for (i, c) in text.char_indices() {
+                                if c == '\n' {
+                                    if x + 8 <= rect.width as i32 && click_point.x >= x &&
+                                    y + 16 <= rect.height as i32 &&
+                                    click_point.y >= y &&
+                                    click_point.y < y + 16 {
+                                        new_text_i = Some(i);
+                                        break;
+                                    }
+                                    x = 0;
+                                    y += 16;
+                                } else if c == '\t' {
+                                    if x + 8 * 4 <= rect.width as i32 && click_point.x >= x &&
+                                    click_point.x < x + 8 * 4 &&
+                                    y + 16 <= rect.height as i32 &&
+                                    click_point.y >= y &&
+                                    click_point.y < y + 16 {
+                                        new_text_i = Some(i);
+                                        break;
+                                    }
+                                    x += 8 * 4;
+                                } else {
+                                    if x + 8 <= rect.width as i32 && click_point.x >= x &&
+                                    click_point.x < x + 8 &&
+                                    y + 16 <= rect.height as i32 &&
+                                    click_point.y >= y &&
+                                    click_point.y < y + 16 {
+                                        new_text_i = Some(i);
+                                        break;
+                                    }
+                                    x += 8;
                                 }
-                                x = 0;
-                                y += 16;
-                            } else if c == '\t' {
-                                if x + 8 * 4 <= rect.width as i32 && click_point.x >= x &&
-                                   click_point.x < x + 8 * 4 &&
-                                   y + 16 <= rect.height as i32 &&
-                                   click_point.y >= y &&
-                                   click_point.y < y + 16 {
-                                    new_text_i = Some(i);
-                                    break;
-                                }
-                                x += 8 * 4;
-                            } else {
-                                if x + 8 <= rect.width as i32 && click_point.x >= x &&
-                                   click_point.x < x + 8 &&
-                                   y + 16 <= rect.height as i32 &&
-                                   click_point.y >= y &&
-                                   click_point.y < y + 16 {
-                                    new_text_i = Some(i);
-                                    break;
-                                }
-                                x += 8;
+                            }
+
+                            if new_text_i.is_none() && x + 8 <= rect.width as i32 &&
+                            click_point.x >= x &&
+                            y + 16 <= rect.height as i32 &&
+                            click_point.y >= y ||
+                            click_point.y >= y + 16 {
+                                new_text_i = Some(text.len());
+                            }
+
+                            if let Some(text_i) = new_text_i {
+                                self.text_i.set(text_i);
                             }
                         }
 
-                        if new_text_i.is_none() && x + 8 <= rect.width as i32 &&
-                           click_point.x >= x &&
-                           y + 16 <= rect.height as i32 &&
-                           click_point.y >= y ||
-                           click_point.y >= y + 16 {
-                            new_text_i = Some(text.len());
-                        }
-
-                        if let Some(text_i) = new_text_i {
-                            self.text_i.set(text_i);
-                        }
+                        self.emit_click(click_point);
                     }
-
-                    self.emit_click(click_point);
                 }
-            }
-            Event::Text { c } => {
-                if focused {
-                    let mut text = self.text.borrow_mut();
-                    let text_i = self.text_i.get();
-                    text.insert(text_i, c);
-                    self.text_i.set(next_i(text.deref(), text_i));
-                    *redraw = true;
-                }
-            }
-            Event::Enter => {
-                if focused {
-                    if self.on_enter.borrow().is_some() {
-                        self.emit_enter();
-                    } else {
+                Event::Text { c } => {
+                    if focused {
                         let mut text = self.text.borrow_mut();
                         let text_i = self.text_i.get();
-                        text.insert(text_i, '\n');
+                        text.insert(text_i, c);
                         self.text_i.set(next_i(text.deref(), text_i));
+                        *redraw = true;
                     }
-                    *redraw = true;
                 }
-            }
-            Event::Backspace => {
-                if focused {
-                    let mut text = self.text.borrow_mut();
-                    let mut text_i = self.text_i.get();
-                    if text_i > 0 {
-                        text_i = prev_i(text.deref(), text_i);
+                Event::Enter => {
+                    if focused {
+                        if self.on_enter.borrow().is_some() {
+                            self.emit_enter();
+                        } else {
+                            let mut text = self.text.borrow_mut();
+                            let text_i = self.text_i.get();
+                            text.insert(text_i, '\n');
+                            self.text_i.set(next_i(text.deref(), text_i));
+                        }
+                        *redraw = true;
+                    }
+                }
+                Event::Backspace => {
+                    if focused {
+                        let mut text = self.text.borrow_mut();
+                        let mut text_i = self.text_i.get();
+                        if text_i > 0 {
+                            text_i = prev_i(text.deref(), text_i);
+                            if text_i < text.len() {
+                                text.remove(text_i);
+                                self.text_i.set(min(text_i, text.len()));
+                            }
+                        }
+                        *redraw = true;
+                    }
+                }
+                Event::Delete => {
+                    if focused {
+                        let mut text = self.text.borrow_mut();
+                        let text_i = self.text_i.get();
                         if text_i < text.len() {
                             text.remove(text_i);
                             self.text_i.set(min(text_i, text.len()));
                         }
+                        *redraw = true;
                     }
-                    *redraw = true;
                 }
-            }
-            Event::Delete => {
-                if focused {
-                    let mut text = self.text.borrow_mut();
-                    let text_i = self.text_i.get();
-                    if text_i < text.len() {
-                        text.remove(text_i);
-                        self.text_i.set(min(text_i, text.len()));
+                Event::Home => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let mut text_i = self.text_i.get();
+                        while text_i > 0 {
+                            if text[.. text_i].chars().rev().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = prev_i(text.deref(), text_i);
+                        }
+                        self.text_i.set(text_i);
+                        *redraw = true;
                     }
-                    *redraw = true;
                 }
-            }
-            Event::Home => {
-                if focused {
-                    let text = self.text.borrow();
-                    let mut text_i = self.text_i.get();
-                    while text_i > 0 {
-                        if text[.. text_i].chars().rev().next() == Some('\n') {
-                            break;
+                Event::End => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let mut text_i = self.text_i.get();
+                        while text_i < text.len() {
+                            if text[text_i ..].chars().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = next_i(text.deref(), text_i);
                         }
-                        text_i = prev_i(text.deref(), text_i);
+                        self.text_i.set(text_i);
+                        *redraw = true;
                     }
-                    self.text_i.set(text_i);
-                    *redraw = true;
                 }
-            }
-            Event::End => {
-                if focused {
-                    let text = self.text.borrow();
-                    let mut text_i = self.text_i.get();
-                    while text_i < text.len() {
-                        if text[text_i ..].chars().next() == Some('\n') {
-                            break;
+                Event::UpArrow => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let mut text_i = self.text_i.get();
+
+                        // Count back to last newline
+                        let mut offset = 0;
+                        while text_i > 0 {
+                            let c = text[.. text_i].chars().rev().next();
+                            text_i = prev_i(text.deref(), text_i);
+                            if c == Some('\n') {
+                                break;
+                            }
+                            offset += 1;
                         }
-                        text_i = next_i(text.deref(), text_i);
+
+                        // Go to newline before last newline
+                        while text_i > 0 {
+                            if text[.. text_i].chars().rev().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = prev_i(text.deref(), text_i);
+                        }
+
+                        // Add back offset
+                        while offset > 0 && text_i < text.len() {
+                            if text[text_i ..].chars().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = next_i(text.deref(), text_i);
+                            offset -= 1;
+                        }
+
+                        self.text_i.set(text_i);
+                        *redraw = true;
                     }
-                    self.text_i.set(text_i);
-                    *redraw = true;
                 }
-            }
-            Event::UpArrow => {
-                if focused {
-                    let text = self.text.borrow();
-                    let mut text_i = self.text_i.get();
+                Event::DownArrow => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let mut text_i = self.text_i.get();
 
-                    // Count back to last newline
-                    let mut offset = 0;
-                    while text_i > 0 {
-                        let c = text[.. text_i].chars().rev().next();
-                        text_i = prev_i(text.deref(), text_i);
-                        if c == Some('\n') {
-                            break;
+                        // Count back to last newline
+                        let mut offset = 0;
+                        while text_i > 0 {
+                            if text[.. text_i].chars().rev().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = prev_i(text.deref(), text_i);
+                            offset += 1;
                         }
-                        offset += 1;
-                    }
 
-                    // Go to newline before last newline
-                    while text_i > 0 {
-                        if text[.. text_i].chars().rev().next() == Some('\n') {
-                            break;
+                        // Go to next newline
+                        while text_i < text.len() {
+                            let c = text[text_i ..].chars().next();
+                            text_i = next_i(text.deref(), text_i);
+                            if c == Some('\n') {
+                                break;
+                            }
                         }
-                        text_i = prev_i(text.deref(), text_i);
-                    }
 
-                    // Add back offset
-                    while offset > 0 && text_i < text.len() {
-                        if text[text_i ..].chars().next() == Some('\n') {
-                            break;
+                        // Add back offset
+                        while offset > 0 && text_i < text.len() {
+                            if text[text_i ..].chars().next() == Some('\n') {
+                                break;
+                            }
+                            text_i = next_i(text.deref(), text_i);
+                            offset -= 1;
                         }
-                        text_i = next_i(text.deref(), text_i);
-                        offset -= 1;
-                    }
 
-                    self.text_i.set(text_i);
-                    *redraw = true;
+                        self.text_i.set(text_i);
+                        *redraw = true;
+                    }
                 }
-            }
-            Event::DownArrow => {
-                if focused {
-                    let text = self.text.borrow();
-                    let mut text_i = self.text_i.get();
-
-                    // Count back to last newline
-                    let mut offset = 0;
-                    while text_i > 0 {
-                        if text[.. text_i].chars().rev().next() == Some('\n') {
-                            break;
+                Event::LeftArrow => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let text_i = self.text_i.get();
+                        if text_i > 0 {
+                            self.text_i.set(prev_i(text.deref(), text_i));
                         }
-                        text_i = prev_i(text.deref(), text_i);
-                        offset += 1;
+                        *redraw = true;
                     }
-
-                    // Go to next newline
-                    while text_i < text.len() {
-                        let c = text[text_i ..].chars().next();
-                        text_i = next_i(text.deref(), text_i);
-                        if c == Some('\n') {
-                            break;
+                }
+                Event::RightArrow => {
+                    if focused {
+                        let text = self.text.borrow();
+                        let text_i = self.text_i.get();
+                        if text_i < text.len() {
+                            self.text_i.set(next_i(text.deref(), text_i));
                         }
+                        *redraw = true;
                     }
+                }
+                _ => (),
+            }
 
-                    // Add back offset
-                    while offset > 0 && text_i < text.len() {
-                        if text[text_i ..].chars().next() == Some('\n') {
-                            break;
-                        }
-                        text_i = next_i(text.deref(), text_i);
-                        offset -= 1;
-                    }
-
-                    self.text_i.set(text_i);
-                    *redraw = true;
-                }
+            if self.grab_focus.check_set(false) {
+                focused = true;
+                *redraw = true;
             }
-            Event::LeftArrow => {
-                if focused {
-                    let text = self.text.borrow();
-                    let text_i = self.text_i.get();
-                    if text_i > 0 {
-                        self.text_i.set(prev_i(text.deref(), text_i));
-                    }
-                    *redraw = true;
-                }
-            }
-            Event::RightArrow => {
-                if focused {
-                    let text = self.text.borrow();
-                    let text_i = self.text_i.get();
-                    if text_i < text.len() {
-                        self.text_i.set(next_i(text.deref(), text_i));
-                    }
-                    *redraw = true;
-                }
-            }
-            _ => (),
         }
-
-        if self.grab_focus.check_set(false) {
-            focused = true;
-            *redraw = true;
-        }
-
         focused
     }
 }


### PR DESCRIPTION
This PR adds:

* An EventFilter trait. It implements two methods, one to call the filter, other to set it. 
The filter is just a closure that takes in the Event, and either returns None if the filter caught it and handled it in a special way, or the Event it received if it doesn't do anything special and wants the default handler to deal with it.

* An implementation of EventFilter on TextBox