### PR TITLE
support for FileManager in List and Window

### DIFF
--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 fn main() {
-    let window = Window::new(Rect::new(100, 100, 420, 420), "Canvas");
+    let mut window = Window::new(Rect::new(100, 100, 420, 420), "Canvas");
 
     let click_pos: Rc<RefCell<Option<Point>>>= Rc::new(RefCell::new(None));
 

--- a/examples/filtered.rs
+++ b/examples/filtered.rs
@@ -4,7 +4,7 @@ use orbtk::{Window, TextBox, Rect, Label, Event};
 use orbtk::traits::{EventFilter, Place, Text};
 
 fn main() {
-    let window = Window::new(Rect::new(100, 100, 420, 420), "Filtered Textbox");
+    let mut window = Window::new(Rect::new(100, 100, 420, 420), "Filtered Textbox");
 
     let label = Label::new();
     label.text("Field below will ignore all 'e' chars.")

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -4,7 +4,7 @@ use orbtk::{ Window, List, Rect, Entry, Button };
 use orbtk::traits::{ Place, Text, Click };
 
 fn main() {
-    let window = Window::new(Rect::new(100, 100, 420, 500), "OrbTK");
+    let mut window = Window::new(Rect::new(100, 100, 420, 500), "OrbTK");
 
     let list = List::new();
     list.position(5, 5).size(400, 400);

--- a/examples/widgets.rs
+++ b/examples/widgets.rs
@@ -4,7 +4,7 @@ use orbtk::{Action, Button, Grid, Image, Label, Menu, Point, ProgressBar, Rect, 
 use orbtk::traits::{Border, Click, Enter, Place, Text};
 
 fn main() {
-    let window = Window::new(Rect::new(100, 100, 420, 730), "OrbTK");
+    let mut window = Window::new(Rect::new(100, 100, 420, 730), "OrbTK");
 
     let x = 10;
     let mut y = 0;

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,6 +11,11 @@ pub enum Event {
         right_button: bool,
     },
 
+    Scroll {
+        x: i32,
+        y: i32,
+    },
+
     Text {
         c: char,
     },

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -1,4 +1,4 @@
-use orbclient::Renderer;
+use orbclient::{Renderer, Color};
 use orbimage;
 use std::cell::{ Cell, RefCell };
 use std::sync::Arc;
@@ -7,16 +7,19 @@ use cell::CheckSet;
 use event::Event;
 use point::Point;
 use rect::Rect;
-use theme::{ ITEM_BACKGROUND, WINDOW_BACKGROUND };
+use theme::{ ITEM_BACKGROUND, WINDOW_BACKGROUND, ITEM_SELECTION };
 use traits::{ Click, Place };
 use widgets::Widget;
+use std::ops::Index;
 
 /// An entry in a list
 /// Each entry stores widgets within. 
 pub struct Entry {
     pub height: Cell<u32>,
     click_callback: RefCell<Option<Arc<Fn(&Entry, Point)>>>,
-    widgets: RefCell<Vec<Arc<Widget>>>
+    widgets: RefCell<Vec<Arc<Widget>>>,
+    pub highlight: Cell<Color>,
+    highlighted: Cell<bool>,
 }
 
 impl Entry {
@@ -25,6 +28,8 @@ impl Entry {
             height: Cell::new(h),
             click_callback: RefCell::new(None),
             widgets: RefCell::new(vec![]),
+            highlight: Cell::new(ITEM_SELECTION),
+            highlighted: Cell::new(false),
         })
     }
 
@@ -57,7 +62,8 @@ pub struct List {
     v_scroll: Cell<i32>,
     current_height: Cell<u32>,
     entries: RefCell<Vec<Arc<Entry>>>,
-    pressed: Cell<bool>
+    pressed: Cell<bool>,
+    selected: Cell<i32>,
 }
 
 impl List {
@@ -68,6 +74,7 @@ impl List {
             current_height: Cell::new(0),
             entries: RefCell::new(vec![]),
             pressed: Cell::new(false),
+            selected: Cell::new(-1),
         })
     }
 
@@ -77,9 +84,9 @@ impl List {
         self.current_height.set(self.current_height.get() + h);
     }
 
-    // Given absolute coordinates, returns the list entry
+    // Given absolute coordinates, returns the list entry index
     // drawn at that point.
-    fn get_entry(&self, p: Point) -> Option<Arc<Entry>> {
+    fn get_entry_index(&self, p: Point) -> i32 {
         if self.rect.get().contains(p) {
             let mut current_y = 0;
             let x = self.rect.get().x;
@@ -87,18 +94,18 @@ impl List {
             let width = self.rect.get().width;
             let scroll = self.v_scroll.get();
 
-            for entry in self.entries.borrow().iter() {
+            for (i, entry) in self.entries.borrow().iter().enumerate() {
                 if Rect::new(x, y+current_y-scroll, width, entry.height.get()).contains(p) {
-                    return Some(entry.clone());
+                    return i as i32
                 }
                 current_y += entry.height.get() as i32
             }
 
-            None
+            -1
         } else {
-            None
+            -1
         }
-    } 
+    }
 
     pub fn scroll(&self, y: i32) {
         let mut set_to = self.v_scroll.get() + y;
@@ -108,6 +115,31 @@ impl List {
             set_to = self.v_scroll.get() as i32;
         }
         self.v_scroll.set(set_to);
+    }
+
+    fn change_selection(&self, i: i32) {
+        if let Some(entry) = self.entries.borrow().get(self.selected.get() as usize) {
+            entry.highlighted.set(false);
+        }
+
+        if let Some(entry) = self.entries.borrow().get(i as usize) {
+            entry.highlighted.set(true);
+            self.selected.set(i);
+
+            let mut y = 0;
+
+            for e in self.entries.borrow().index(0..(i as usize)) {
+                y += e.height.get();
+            }
+
+            let v_scroll = self.v_scroll.get();
+
+            if y < v_scroll as u32 {
+                self.scroll(y as i32 - v_scroll);
+            } else if (y + entry.height.get() as u32) > (v_scroll as u32 + self.rect.get().height) {
+                self.scroll((y + entry.height.get()) as i32 - (v_scroll + self.rect.get().height as i32));
+            }
+        }
     }
 }
 
@@ -128,14 +160,19 @@ impl Widget for List {
 
         for entry in self.entries.borrow().iter() {
             let mut image = orbimage::Image::new(width, entry.height.get());
-            image.set(ITEM_BACKGROUND);
+
+            if entry.highlighted.get() {
+                image.set(entry.highlight.get());
+            } else {
+                image.set(ITEM_BACKGROUND);
+            }
 
             for widget in entry.widgets().borrow().iter() {
                 widget.draw(&mut image, false)
             }
-            
+
             let image = image.data();
-            target.image(x, y+current_y-self.v_scroll.get(), width, entry.height.get(), &image);
+            target.image(x, current_y-self.v_scroll.get(), width, entry.height.get(), &image);
 
             current_y += entry.height.get() as i32
         }
@@ -168,16 +205,64 @@ impl Widget for List {
                     }
                 }
 
-                if click {
-                    if let Some(entry) = self.get_entry(point) { 
-                        entry.emit_click(point)
+                let i = self.get_entry_index(point);
+
+                if i >= 0 {
+                    if click {
+                        if let Some(entry) = self.entries.borrow().get(i as usize) {
+                            entry.emit_click(point);
+                        }
+                    }
+
+                    if self.selected.get() != i {
+                        if self.selected.get() != -1 {
+                            if let Some(entry) = self.entries.borrow().get(self.selected.get() as usize) {
+                                entry.highlighted.set(false);
+                            }
+                        }
+
+                        if let Some(entry) = self.entries.borrow().get(i as usize) {
+                            entry.highlighted.set(true);
+                            self.selected.set(i);
+                        }
+                        *redraw = true
                     }
                 }
             },
+            Event::UpArrow => {
+                if self.selected.get() > 0 {
+                    self.change_selection(self.selected.get() - 1);
+                    *redraw = true
+                } else if self.selected.get() == -1 {
+                    self.change_selection(0);
+                    *redraw = true
+                }
+            },
+            Event::DownArrow => {
+                if self.selected.get() < self.entries.borrow().len() as i32 - 1 {
+                    self.change_selection(self.selected.get() + 1);
+                    *redraw = true
+                }
+            },
+            Event::Home => {
+                self.change_selection(0);
+                *redraw = true
+            },
+            Event::End => {
+                self.change_selection(self.entries.borrow().len() as i32 - 1);
+                *redraw = true
+            },
+            Event::Enter => {
+                let i = self.selected.get();
 
-            Event::UpArrow => { self.scroll(10); *redraw = true }
-            Event::DownArrow => { self.scroll(-10); *redraw = true }
-
+                if let Some(entry) = self.entries.borrow().get(i as usize) {
+                    entry.emit_click(Point { x: 0, y: 0});
+                }
+            },
+            Event::Scroll { y, .. } => {
+                self.scroll(y * 2);
+                *redraw = true;
+            },
             _ => {}
         }
         focused


### PR DESCRIPTION
## `List`
- there is now a concept of a `selected` entry, which will be highlighted
- up/down changes the current selection rather than scrolling (but will scroll if entry is outside the viewable area)
- responds to `ScrollEvent`
- supports `home`/`end` to jump to top and bottom
- `enter` simulates a click on the entry

## `Window`
This PR breaks `exec` up into a few pieces that can be called independently. This allows FileManager to still maintain its own event queue. In the future I'd like to put everything back behind `exec`, but not at the window level.

Instead I think it would be nice to have an `Application` which is capable of housing multiple `Window`s and accepts some sort of callback that allows the application to hook into the application loop. Which would allow behavior like in this FileManager PR (https://github.com/redox-os/orbutils/pull/19), but without the app having to poke at `Window` in very specific ways.