### PR TITLE
Fix scroll direction in List widget

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -106,7 +106,7 @@ impl List {
     }
 
     pub fn scroll(&self, y: i32) {
-        let mut set_to = self.v_scroll.get() + y;
+        let mut set_to = self.v_scroll.get() - y;
         if set_to < 0 {
             set_to = 0;
         } else if self.rect.get().height as i32 + set_to > self.current_height.get() as i32 {


### PR DESCRIPTION
I've noticed, that scroll in orbtk List widget is inverted, which affects Redox file manager.

Comparing to orbutils browser, which doesn't use orbtk, `scroll_event` value is subtracted from current offset:
https://github.com/redox-os/orbutils/blob/master/src/browser/main.rs#L707
```Rust
offset.1 = cmp::max(0, cmp::min(cmp::max(0, max_offset.1 - window_h), offset.1 - scroll_event.y * 48));
```
But in orbtk `List` value is added instead, so changing sign should fix direction.