### PR TITLE
Unpress buttons regardless of left_button state

### DIFF
--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -131,10 +131,8 @@ impl Widget for Button {
                         *redraw = true;
                     }
 
-                    if !left_button {
-                        if self.pressed.check_set(false) {
-                            *redraw = true;
-                        }
+                    if self.pressed.check_set(false) {
+                        *redraw = true;
                     }
                 }
 


### PR DESCRIPTION
If you click and hold on a button and move the cursor to another button while still holding down, both buttons become highlighted. This causes the `pressed` state to be reset if the mouse exits the button, regardless of if the left button is pressed