### PR TITLE
[WIP] Allow apps to add classes and pseudoclasses to widgets

### DIFF
--- a/examples/exampletheme.css
+++ b/examples/exampletheme.css
@@ -25,14 +25,32 @@ label {
     border-width: 0;
 }
 
+label.padded {
+    border-width: 1;
+    border-radius: 20;
+}
+
+label.padded :clicked {
+    background: #FFC945;
+}
+
 menu {}
 
 menu-button, action, separator {
     border-width: 0;
 }
 
+action.critical {
+    background: #D93636;
+    color: #000000;
+}
+
 menu-button :active, action :active {
     background: #8fd2db;
+}
+
+action.critical :active {
+    background: #F18282;
 }
 
 progress {

--- a/examples/themed.rs
+++ b/examples/themed.rs
@@ -1,7 +1,7 @@
 extern crate orbtk;
 use orbtk::{Action, Button, Grid, Image, Label, Menu, Point, ProgressBar, Rect, Separator, TextBox, Window, WindowBuilder};
 use orbtk::theme::Theme;
-use orbtk::traits::{Click, Enter, Place, Text};
+use orbtk::traits::{Click, Enter, Place, Text, Style};
 
 fn main() {
     let theme = Theme::from_path("examples/exampletheme.css").unwrap();
@@ -89,8 +89,11 @@ fn main() {
         .size(400, 120)
         .text("Test Offset")
         .text_offset(50, 50)
+        .with_class("padded")
         .on_click(|label: &Label, _point: Point| {
-            label.text("Clicked");
+            label
+                .text("Clicked")
+                .with_pseudo_class("clicked");
         });
     window.add(&offset_label);
 
@@ -125,6 +128,7 @@ fn main() {
 
     {
         let action = Action::new("Label Two");
+        action.with_class("critical");
         let offset_label_clone = offset_label.clone();
         action.on_click(move |_action: &Action, _point: Point| {
             offset_label_clone.text.set("Two".to_owned());

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -4,6 +4,7 @@ pub use self::event_filter::EventFilter;
 pub use self::place::Place;
 pub use self::resize::Resize;
 pub use self::text::Text;
+pub use self::style::Style;
 
 mod click;
 mod enter;
@@ -11,3 +12,4 @@ mod event_filter;
 mod place;
 mod resize;
 mod text;
+mod style;

--- a/src/traits/style.rs
+++ b/src/traits/style.rs
@@ -1,0 +1,4 @@
+pub trait Style {
+    fn with_class<S: Into<String>>(&self, class: S) -> &Self;
+    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self;
+}

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -8,11 +8,12 @@ use event::Event;
 use point::Point;
 use rect::Rect;
 use theme::{Theme, Selector};
-use traits::{Click, Place, Text};
+use traits::{Click, Place, Text, Style};
 use widgets::Widget;
 
 pub struct Label {
     pub rect: Cell<Rect>,
+    pub selector: CloneCell<Selector>,
     pub border: Cell<bool>,
     pub border_radius: Cell<u32>,
     pub text: CloneCell<String>,
@@ -25,6 +26,7 @@ impl Label {
     pub fn new() -> Arc<Self> {
         Arc::new(Label {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("label"))),
             border: Cell::new(false),
             border_radius: Cell::new(0),
             text: CloneCell::new(String::new()),
@@ -62,6 +64,18 @@ impl Text for Label {
     }
 }
 
+impl Style for Label {
+    fn with_class<S: Into<String>>(&self, class: S) -> &Self {
+        self.selector.set(self.selector.get().with_class(class));
+        self
+    }
+
+    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self {
+        self.selector.set(self.selector.get().with_pseudo_class(pseudo_class));
+        self
+    }
+}
+
 impl Widget for Label {
     fn name(&self) -> &str {
         "Label"
@@ -73,8 +87,9 @@ impl Widget for Label {
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
         let rect = self.rect.get();
+        let selector = &self.selector.get();
 
-        draw_box(renderer, rect, theme, &Selector::new(Some("label")));
+        draw_box(renderer, rect, theme, selector);
 
         let text = self.text.borrow();
 
@@ -85,7 +100,7 @@ impl Widget for Label {
                 point.y += 16;
             } else {
                 if point.x + 8 <= rect.width as i32 && point.y + 16 <= rect.height as i32 {
-                    renderer.char(point.x + rect.x, point.y + rect.y, c, theme.color("color", &"label".into()));
+                    renderer.char(point.x + rect.x, point.y + rect.y, c, theme.color("color", selector));
                 }
                 point.x += 8;
             }


### PR DESCRIPTION
Here is my idea of a trait to allow apps to add classes/pseudoclasses to their widgets for use as conditional styling. For example, on the orbutils calendar the current date could be given a "today" class, so the background colour for that label can live entirely within the CSS file for the application.

**TODO**:

- Add `Style` trait to other relevant classes, and make sure they use the correct Selector object and don't create their own in `draw`
- Add "without_class" and similar so apps can remove classes that were added

**Downsides**: Apps that want to change a single widget's style needs to create a theme CSS that includes all the defaults. This could be mitigated if we could merge two theme objects, so you can create a default theme and then add extras from another.