### PR TITLE
Add Style trait to remaining widgets, allow apps to remove classes

### DIFF
--- a/examples/themed.rs
+++ b/examples/themed.rs
@@ -143,6 +143,7 @@ fn main() {
         let offset_label_clone = offset_label.clone();
         action.on_click(move |_action: &Action, _point: Point| {
             offset_label_clone.text.set("Text Offset".to_owned());
+            offset_label_clone.without_pseudo_class("clicked");
         });
         menu.add(&action);
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -176,8 +176,18 @@ impl Selector {
         self
     }
 
+    pub fn without_class<S: Into<String>>(mut self, class: S) -> Self {
+        self.classes.remove(&class.into());
+        self
+    }
+
     pub fn with_pseudo_class<S: Into<String>>(mut self, pseudo_class: S) -> Self {
         self.pseudo_classes.insert(pseudo_class.into());
+        self
+    }
+
+    pub fn without_pseudo_class<S: Into<String>>(mut self, pseudo_class: S) -> Self {
+        self.pseudo_classes.remove(&pseudo_class.into());
         self
     }
 }

--- a/src/traits/style.rs
+++ b/src/traits/style.rs
@@ -1,4 +1,26 @@
+use cell::{CloneCell};
+use theme::Selector;
+
 pub trait Style {
-    fn with_class<S: Into<String>>(&self, class: S) -> &Self;
-    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self;
+    fn selector(&self) -> &CloneCell<Selector>;
+
+    fn with_class<S: Into<String>>(&self, class: S) -> &Self {
+        self.selector().set(self.selector().get().with_class(class));
+        self
+    }
+
+    fn without_class<S: Into<String>>(&self, class: S) -> &Self {
+        self.selector().set(self.selector().get().without_class(class));
+        self
+    }
+
+    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self {
+        self.selector().set(self.selector().get().with_pseudo_class(pseudo_class));
+        self
+    }
+
+    fn without_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self {
+        self.selector().set(self.selector().get().without_pseudo_class(pseudo_class));
+        self
+    }
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -8,11 +8,12 @@ use event::Event;
 use point::Point;
 use rect::Rect;
 use theme::{Selector, Theme};
-use traits::{Click, Place, Text};
+use traits::{Click, Place, Text, Style};
 use widgets::Widget;
 
 pub struct Button {
     pub rect: Cell<Rect>,
+    pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_offset: Cell<Point>,
     click_callback: RefCell<Option<Arc<Fn(&Button, Point)>>>,
@@ -24,6 +25,7 @@ impl Button {
     pub fn new() -> Arc<Self> {
         Arc::new(Button {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("button"))),
             text: CloneCell::new(String::new()),
             text_offset: Cell::new(Point::default()),
             click_callback: RefCell::new(None),
@@ -60,6 +62,12 @@ impl Text for Button {
     }
 }
 
+impl Style for Button {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
 impl Widget for Button {
     fn name(&self) -> &str {
         "Button"
@@ -70,7 +78,7 @@ impl Widget for Button {
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
-        let mut selector = Selector::new(Some("button")).with_pseudo_class(
+        let mut selector = self.selector.get().with_pseudo_class(
             if self.pressed.get() {
                 "active"
             } else {

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -65,14 +65,8 @@ impl Text for Label {
 }
 
 impl Style for Label {
-    fn with_class<S: Into<String>>(&self, class: S) -> &Self {
-        self.selector.set(self.selector.get().with_class(class));
-        self
-    }
-
-    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self {
-        self.selector.set(self.selector.get().with_pseudo_class(pseudo_class));
-        self
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
     }
 }
 

--- a/src/widgets/menu.rs
+++ b/src/widgets/menu.rs
@@ -14,6 +14,7 @@ use widgets::Widget;
 
 pub struct Menu {
     pub rect: Cell<Rect>,
+    selector: CloneCell<Selector>,
     text: CloneCell<String>,
     text_offset: Cell<Point>,
     entries: RefCell<Vec<Arc<Entry>>>,
@@ -24,6 +25,7 @@ pub struct Menu {
 
 pub struct Separator {
     pub rect: Cell<Rect>,
+    selector: CloneCell<Selector>,
 }
 
 pub trait Entry: Widget {
@@ -34,6 +36,7 @@ impl Menu {
     pub fn new<S: Into<String>>(name: S) -> Arc<Self> {
         Arc::new(Menu {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("menu"))),
             text: CloneCell::new(name.into()),
             text_offset: Cell::new(Point::default()),
             entries: RefCell::new(Vec::new()),
@@ -95,6 +98,12 @@ impl Click for Menu {
 
 impl Place for Menu {}
 
+impl Style for Menu {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
 impl Widget for Menu {
     fn name(&self) -> &str {
         "Menu"
@@ -108,6 +117,7 @@ impl Widget for Menu {
         let rect = self.rect.get();
 
         if self.activated.get() {
+            //TODO: set this selector as the child of self.selector
             draw_box(renderer, rect, theme, &Selector::new(Some("menu-button")).with_pseudo_class("active"));
 
             let mut max_width = 0;
@@ -124,8 +134,9 @@ impl Widget for Menu {
                 max_width as u32 + 2, max_height as u32 + 2,
             );
 
-            draw_box(renderer, entries_rect, theme, &Selector::new(Some("menu")).with_pseudo_class("active"));
+            draw_box(renderer, entries_rect, theme, &self.selector.get().with_pseudo_class("active"));
         } else {
+            //TODO: set this selector as the child of self.selector
             draw_box(renderer, rect, theme, &Selector::new(Some("menu-button")).with_pseudo_class("inactive"));
         }
 
@@ -257,14 +268,8 @@ impl Text for Action {
 }
 
 impl Style for Action {
-    fn with_class<S: Into<String>>(&self, class: S) -> &Self {
-        self.selector.set(self.selector.get().with_class(class));
-        self
-    }
-
-    fn with_pseudo_class<S: Into<String>>(&self, pseudo_class: S) -> &Self {
-        self.selector.set(self.selector.get().with_pseudo_class(pseudo_class));
-        self
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
     }
 }
 
@@ -356,7 +361,14 @@ impl Separator {
     pub fn new() -> Arc<Self> {
         Arc::new(Separator {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("separator"))),
         })
+    }
+}
+
+impl Style for Separator {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
     }
 }
 
@@ -371,10 +383,11 @@ impl Widget for Separator {
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
         let rect = self.rect.get();
-        draw_box(renderer, rect, theme, &"separator".into());
+        let selector = &self.selector.get();
+        draw_box(renderer, rect, theme, selector);
 
         let line_y = rect.y + rect.height as i32 / 2;
-        renderer.rect(rect.x, line_y, rect.width, 1, theme.color("color", &"separator".into()));
+        renderer.rect(rect.x, line_y, rect.width, 1, theme.color("color", selector));
     }
 
     fn event(&self, event: Event, _focused: bool, _redraw: &mut bool) -> bool {

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -3,17 +3,18 @@ use std::cell::{Cell, RefCell};
 use std::cmp::{min, max};
 use std::sync::Arc;
 
-use cell::CheckSet;
+use cell::{CloneCell, CheckSet};
 use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
 use theme::{Theme, Selector};
-use traits::{Click, Place};
+use traits::{Click, Place, Style};
 use widgets::Widget;
 
 pub struct ProgressBar {
     pub rect: Cell<Rect>,
+    pub selector: CloneCell<Selector>,
     pub value: Cell<i32>,
     pub minimum: i32,
     pub maximum: i32,
@@ -25,6 +26,7 @@ impl ProgressBar {
     pub fn new() -> Arc<Self> {
         Arc::new(ProgressBar {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("progress-bar"))),
             value: Cell::new(0),
             minimum: 0,
             maximum: 100,
@@ -54,6 +56,12 @@ impl Click for ProgressBar {
 
 impl Place for ProgressBar {}
 
+impl Style for ProgressBar {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
 impl Widget for ProgressBar {
     fn name(&self) -> &str {
         "ProgressBar"
@@ -72,15 +80,16 @@ impl Widget for ProgressBar {
                                 ..self.rect.get()
                             };
 
-        let selector = Selector::new(Some("progress-bar"));
+        let selector = &self.selector.get();
 
-        draw_box(renderer, rect, theme, &selector);
+        draw_box(renderer, rect, theme, selector);
 
-        let b_r = theme.get("border-radius", &selector).map(|v| v.uint().unwrap()).unwrap_or(1);
-        let b_t = theme.get("border-width", &selector).map(|v| v.uint().unwrap()).unwrap_or(0);
+        let b_r = theme.get("border-radius", selector).map(|v| v.uint().unwrap()).unwrap_or(1);
+        let b_t = theme.get("border-width", selector).map(|v| v.uint().unwrap()).unwrap_or(0);
 
 
         if progress_rect.width >=  b_t + b_r * 2 {
+            //TODO: set this selector as the child of self.selector
             draw_box(renderer, progress_rect, theme, &Selector::new(Some("progress")));
         }
     }

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -10,7 +10,7 @@ use event::Event;
 use point::Point;
 use rect::Rect;
 use theme::{Theme, Selector};
-use traits::{Click, Enter, EventFilter, Place, Text};
+use traits::{Click, Enter, EventFilter, Place, Text, Style};
 use widgets::Widget;
 
 /// Find next character index
@@ -27,6 +27,7 @@ fn prev_i(text: &str, text_i: usize) -> usize {
 
 pub struct TextBox {
     pub rect: Cell<Rect>,
+    pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_i: Cell<usize>,
     pub text_offset: Cell<Point>,
@@ -51,6 +52,7 @@ impl TextBox {
     pub fn new() -> Arc<Self> {
         Arc::new(TextBox {
             rect: Cell::new(Rect::default()),
+            selector: CloneCell::new(Selector::new(Some("text-box"))),
             text: CloneCell::new(String::new()),
             text_i: Cell::new(0),
             text_offset: Cell::new(Point::default()),
@@ -132,6 +134,12 @@ impl Text for TextBox {
     }
 }
 
+impl Style for TextBox {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
 impl Widget for TextBox {
     fn name(&self) -> &str {
         "TextBox"
@@ -144,7 +152,7 @@ impl Widget for TextBox {
     fn draw(&self, renderer: &mut Renderer, focused: bool, theme: &Theme) {
         let rect = self.rect.get();
 
-        let mut selector = Selector::new(Some("text-box"));
+        let mut selector = self.selector.get();
 
         if focused {
             selector = selector.with_pseudo_class("focus");
@@ -165,6 +173,7 @@ impl Widget for TextBox {
             let mut c_r = Rect::new(x + rect.x, y + rect.y, 8, 16);
             if c == '\n' {
                 if focused && i == text_i && rect.contains_rect(&c_r) {
+                    //TODO: set this selector as the child of self.selector
                     draw_box(renderer, Rect::new(x + rect.x, y + rect.y, 8, 16), theme, &"selection".into());
                 }
 
@@ -174,6 +183,7 @@ impl Widget for TextBox {
                 c_r.width = 8 * 4;
 
                 if focused && i == text_i && rect.contains_rect(&c_r) {
+                    //TODO: set this selector as the child of self.selector
                     draw_box(renderer, Rect::new(x + rect.x, y + rect.y, 8 * 4, 16), theme, &"selection".into());
                 }
 
@@ -181,6 +191,7 @@ impl Widget for TextBox {
             } else {
                 if rect.contains_rect(&c_r) {
                     if i == text_i && focused {
+                        //TODO: set this selector as the child of self.selector
                         draw_box(renderer, Rect::new(x + rect.x, y + rect.y, 8, 16), theme, &"selection".into());
                     }
                     if let Some(mask_c) = self.mask_char.get() {
@@ -196,6 +207,7 @@ impl Widget for TextBox {
 
         let c_r = Rect::new(x + rect.x, y + rect.y, 8, 16);
         if focused && text.len() == text_i && rect.contains_rect(&c_r) {
+            //TODO: set this selector as the child of self.selector
             draw_box(renderer, Rect::new(x + rect.x, y + rect.y, 8, 16), theme, &"selection".into());
         }
     }


### PR DESCRIPTION
Move implementation of Style's with/without_class/pseudoclass into the trait, to reduce repeated code.

There are quite a few sub-selectors inside widgets, like combo-box-toggle or menu-button. The classes that are added to a widget don't affect those selectors yet. Once complex selectors are implemented we could set them as children of the main selector, so to style them you do `combo-box.class > combo-box-toggle`. Better yet, if we implement pseudoelements they could be styled like `combo-box.class::toggle`. I added TODO comments to all these places