### PR TITLE
Fix bug when x > 200 the entries of Combobox are not drawn.

### DIFF
--- a/src/widgets/combo_box.rs
+++ b/src/widgets/combo_box.rs
@@ -86,7 +86,7 @@ impl Widget for Entry {
 
         let mut point = Point::new(rect.x + offset.x, rect.y + rect.height as i32 / 2 - 8);
         for c in self.text.get().chars() {
-            if point.x + 8 <= rect.width as i32 - 2 * offset.x {
+            if point.x + 8 <= rect.x +  rect.width as i32 - offset.x {
                 renderer.char(point.x, point.y, c, theme.color("color", &selector));
             }
             point.x += 8;
@@ -326,11 +326,11 @@ impl Widget for ComboBox {
         }
 
         // draw selected text
-        let mut point = Point::new(rect.x + offset.x - 8, rect.y + rect.height as i32 / 2 - 8);
+        let mut point = Point::new(rect.x + offset.x, rect.y + rect.height as i32 / 2 - 8);
         for c in self.text.get().chars() {
-            if point.x + 8 <= rect.width as i32 - toggle_rect.width as i32 - 2 * offset.x {
+            if point.x + 8 <= rect.x + rect.width as i32 - toggle_rect.width as i32 - 2 * offset.x {
                 renderer.char(
-                    point.x + rect.x,
+                    point.x,
                     point.y,
                     c,
                     theme.color("color", &"label".into()),


### PR DESCRIPTION
From chat:

@flovanro Hi!  I'm trying to use ComboBox : if I place the widget using  .position(x,y)  when x is > 200 the entries are progressively chopped until they completely disappear.
I think there is something wrong when checking if the entry fits inside the flyout rect (or the Entry rect.width is not updated correctly). 
(orbtk/src/widgets/combo_box.rs  line 87)
let mut point = Point::new(rect.x + offset.x, rect.y + rect.height as i32 / 2 - 8);
        for c in self.text.get().chars() {
            if point.x + 8 <= rect.width as i32 - 2 * offset.x {                                            <--------- commenting out this line  I get the text back, but it is not a proper fix. 
                renderer.char(point.x, point.y, c, theme.color("color", &selector));
            }
            point.x += 8;
        }
Are you affected by the same bug? Could you fix it? Should I make an issue?
Thank you

#60