### PR TITLE
Widget children tree part one

### DIFF
--- a/examples/widgets.rs
+++ b/examples/widgets.rs
@@ -1,6 +1,6 @@
 extern crate orbtk;
 
-use orbtk::{Action, Button, ComboBox, Grid, Image, Label, Menu, Point, ProgressBar, Rect, Separator, TextBox, Window};
+use orbtk::{Action, Button, ComboBox, TestButton, Grid, Image, Label, Menu, Point, ProgressBar, Rect, Separator, TextBox, Window};
 use orbtk::traits::{Click, Enter, Place, Text};
 
 fn main() {
@@ -29,12 +29,12 @@ fn main() {
         .text_offset(6, 6);
     window.add(&text_box);
 
-    let button = Button::new();
+    let button = TestButton::new();
     button.position(x + text_box.rect.get().width as i32 + 8, y)
         .size(48 + 12, text_box.rect.get().height)
         .text("Update")
         .text_offset(6, 6)
-        .on_click(move |_button: &Button, _point: Point| {
+        .on_click(move |_button: &TestButton, _point: Point| {
             text_box.emit_enter();
         });
     window.add(&button);

--- a/examples/widgets.rs
+++ b/examples/widgets.rs
@@ -3,6 +3,8 @@ extern crate orbtk;
 use orbtk::{Action, Button, ComboBox, TestButton, Grid, Image, Label, Menu, Point, ProgressBar, Rect, Separator, TextBox, Window};
 use orbtk::traits::{Click, Enter, Place, Text};
 
+// commit: children placement / arrangement, focus manager focused widget, add child 
+
 fn main() {
     let mut window = Window::new(Rect::new(100, 100, 420, 768), "OrbTK");
 
@@ -31,9 +33,7 @@ fn main() {
 
     let button = TestButton::new();
     button.position(x + text_box.rect.get().width as i32 + 8, y)
-        .size(48 + 12, text_box.rect.get().height)
         .text("Update")
-        .text_offset(6, 6)
         .on_click(move |_button: &TestButton, _point: Point| {
             text_box.emit_enter();
         });

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,16 +1,21 @@
 use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::sync::Arc;
 
 pub trait CheckSet<T> {
     fn check_set(&self, value: T) -> bool;
 }
 
-pub struct CloneCell<T: Clone> {
-    inner: RefCell<T>,
+pub struct CloneCell<T: Clone + 'static> {
+    inner: Arc<RefCell<T>>,
+    change_callbacks: Arc<RefCell<Vec<Arc<Fn(T)>>>>,
 }
 
 impl<T: Clone> CloneCell<T> {
     pub fn new(value: T) -> Self {
-        CloneCell { inner: RefCell::new(value) }
+        CloneCell {
+            inner: Arc::new(RefCell::new(value)),
+            change_callbacks: Arc::new(RefCell::new(vec![])),
+        }
     }
 
     pub fn borrow(&self) -> Ref<T> {
@@ -27,10 +32,40 @@ impl<T: Clone> CloneCell<T> {
 
     pub fn set(&self, value: T) {
         *self.inner.borrow_mut() = value;
+        self.raise_changed((*self.inner.borrow()).clone());
+    }
+
+    pub fn bind(&self, other: &CloneCell<T>) {
+        self.set(other.get());
+        let self_value = self.inner.clone();
+        let change_callbacks = self.change_callbacks.clone();
+
+        other.on_changed(move |value: T| {
+            *self_value.borrow_mut() = value.clone();
+
+            for callback in &*change_callbacks.borrow() {
+                callback(value.clone())
+            }
+        });
+    }
+
+    fn raise_changed(&self, value: T) {
+        let change_callbacks = self.change_callbacks.clone();
+        for callback in &*change_callbacks.borrow() {
+            callback(value.clone())
+        }
+    }
+
+    pub fn on_changed<F: Fn(T) + 'static>(&self, func: F) -> &Self {
+        self.change_callbacks.borrow_mut().push(Arc::new(func));
+        self
     }
 }
 
-impl<T: Copy> CheckSet<T> for Cell<T> where T: PartialOrd {
+impl<T: Copy> CheckSet<T> for Cell<T>
+where
+    T: PartialOrd,
+{
     fn check_set(&self, value: T) -> bool {
         if value != self.get() {
             self.set(value);
@@ -41,7 +76,10 @@ impl<T: Copy> CheckSet<T> for Cell<T> where T: PartialOrd {
     }
 }
 
-impl<T: Copy> CheckSet<T> for CloneCell<T> where T: PartialOrd {
+impl<T: Copy> CheckSet<T> for CloneCell<T>
+where
+    T: PartialOrd,
+{
     fn check_set(&self, value: T) -> bool {
         let mut borrow = self.inner.borrow_mut();
         if value != *borrow {

--- a/src/focus_manager.rs
+++ b/src/focus_manager.rs
@@ -1,0 +1,29 @@
+use std::cell::RefCell;
+use std::sync::Arc;
+use widgets::Widget;
+
+pub struct FocusManager {
+    focused_widget: RefCell<Option<Arc<Widget>>>
+}
+
+impl FocusManager {
+    pub fn new() -> Self {
+        FocusManager {
+            focused_widget: RefCell::new(None),
+        }
+    }
+
+    pub fn request_focus(&self, widget: &Arc<Widget>) {
+        (*self.focused_widget.borrow_mut()) = Some(widget.clone());
+    }
+
+    pub fn focused(&self, widget: &Arc<Widget>) -> bool {
+        if let Some(ref focused_widget) = *self.focused_widget.borrow_mut() {
+            if Arc::ptr_eq(&widget, &focused_widget) {
+                return true
+            } 
+        }
+
+        false
+    }
+}

--- a/src/focus_manager.rs
+++ b/src/focus_manager.rs
@@ -26,4 +26,8 @@ impl FocusManager {
 
         false
     }
+
+    pub fn focused_widget(&self) -> &RefCell<Option<Arc<Widget>>> {
+        &self.focused_widget
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ pub use orbclient::renderer::Renderer;
 
 pub use cell::CloneCell;
 pub use dialogs::*;
+pub use primitives::*;
 pub use event::{Event, KeyEvent};
+pub use self::focus_manager::FocusManager;
 pub use point::Point;
 pub use rect::Rect;
 pub use traits::*;
@@ -23,7 +25,9 @@ pub use window::{InnerWindow, Window, WindowBuilder};
 
 pub mod cell;
 pub mod dialogs;
+pub mod primitives;
 pub mod event;
+pub mod focus_manager;
 pub mod point;
 pub mod rect;
 pub mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use self::focus_manager::FocusManager;
 pub use point::Point;
 pub use rect::Rect;
 pub use traits::*;
+pub use thickness::Thickness;
 pub use widgets::*;
 pub use window::{InnerWindow, Window, WindowBuilder};
 
@@ -35,3 +36,4 @@ pub mod widgets;
 pub mod window;
 pub mod draw;
 pub mod theme;
+pub mod thickness;

--- a/src/primitives/image.rs
+++ b/src/primitives/image.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Theme};
 use traits::{Click, Place};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -16,6 +17,7 @@ pub struct Image {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub image: RefCell<orbimage::Image>,
     click_callback: RefCell<Option<Arc<Fn(&Image, Point)>>>,
@@ -36,6 +38,7 @@ impl Image {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             image: RefCell::new(image),
             click_callback: RefCell::new(None)
@@ -77,6 +80,10 @@ impl Widget for Image {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {

--- a/src/primitives/image.rs
+++ b/src/primitives/image.rs
@@ -9,10 +9,14 @@ use point::Point;
 use rect::Rect;
 use theme::{Theme};
 use traits::{Click, Place};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub struct Image {
     pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     pub image: RefCell<orbimage::Image>,
     click_callback: RefCell<Option<Arc<Fn(&Image, Point)>>>,
 }
@@ -29,6 +33,10 @@ impl Image {
     pub fn from_image(image: orbimage::Image) -> Arc<Self> {
         Arc::new(Image {
             rect: Cell::new(Rect::new(0, 0, image.width(), image.height())),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             image: RefCell::new(image),
             click_callback: RefCell::new(None)
         })
@@ -63,6 +71,18 @@ impl Widget for Image {
         &self.rect
     }
 
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
     fn draw(&self, renderer: &mut Renderer, _focused: bool, _theme: &Theme) {
         let rect = self.rect.get();
         let image = self.image.borrow();
@@ -83,5 +103,9 @@ impl Widget for Image {
         }
 
         focused
+    }
+    
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,0 +1,7 @@
+pub use self::image::Image;
+pub use self::rectangle::Rectangle;
+pub use self::text::Text;
+
+mod image;
+mod rectangle;
+mod text;

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,7 +1,7 @@
 pub use self::image::Image;
 pub use self::rectangle::Rectangle;
-pub use self::text::Text;
+pub use self::text_widget::TextWidget;
 
 mod image;
 mod rectangle;
-mod text;
+mod text_widget;

--- a/src/primitives/rectangle.rs
+++ b/src/primitives/rectangle.rs
@@ -6,6 +6,7 @@ use cell::CloneCell;
 use draw::draw_box;
 use rect::{Rect};
 use point::Point;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Place, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -15,6 +16,7 @@ pub struct Rectangle {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
 }
@@ -26,6 +28,7 @@ impl Rectangle {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("Rectangle"))),
         })
@@ -55,6 +58,10 @@ impl Widget for Rectangle {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {

--- a/src/primitives/rectangle.rs
+++ b/src/primitives/rectangle.rs
@@ -1,0 +1,71 @@
+use orbclient::Renderer;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+
+use cell::CloneCell;
+use draw::draw_box;
+use rect::{Rect};
+use point::Point;
+use theme::{Selector, Theme};
+use traits::{Place, Style};
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
+
+pub struct Rectangle {
+    pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    pub selector: CloneCell<Selector>,
+}
+
+impl Rectangle {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Rectangle {
+            rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
+            selector: CloneCell::new(Selector::new(Some("Rectangle"))),
+        })
+    }
+}
+
+impl Place for Rectangle {}
+
+impl Style for Rectangle {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
+impl Widget for Rectangle {
+    fn name(&self) -> &str {
+        "Rectangle"
+    }
+
+    fn rect(&self) -> &Cell<Rect> {
+        &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
+        draw_box(renderer, self.rect().get(), theme, &self.selector().get());
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
+    }
+}

--- a/src/primitives/text.rs
+++ b/src/primitives/text.rs
@@ -1,0 +1,109 @@
+use orbclient::Renderer;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+
+use cell::CloneCell;
+use event::Event;
+use rect::Rect;
+use point::Point;
+use theme::{Selector, Theme};
+use traits::{Place, Style};
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
+
+pub struct Text {
+    pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    pub selector: CloneCell<Selector>,
+    pub text: CloneCell<String>,
+}
+
+impl Text {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Text {
+            rect: Cell::new(Rect::new(0, 0, 0, 16)),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
+            selector: CloneCell::new(Selector::new(Some("Text"))),
+            text: CloneCell::new(String::new()),
+        })
+    }
+
+    pub fn text<S: Into<String>>(&self, text: S) -> &Self {
+        self.text.set(text.into());
+        self.adjust_width();
+        self
+    }
+
+    fn adjust_width(&self) {
+        let mut rect = self.rect.get();
+        rect.width =  self.text.get().len() as u32 * 8;
+        self.rect.set(rect);
+    }
+}
+
+impl Place for Text {}
+
+impl Style for Text {
+    fn selector(&self) -> &CloneCell<Selector> {
+        &self.selector
+    }
+}
+
+impl Widget for Text {
+    fn name(&self) -> &str {
+        "Text"
+    }
+
+    fn rect(&self) -> &Cell<Rect> {
+        &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
+        let mut rect = self.rect().get();
+        let x = rect.x;
+        let selector = &self.selector().get();
+        let text = self.text.get();
+       
+        for c in text.chars() {
+            if c == '\n' {
+                rect.x = x;
+                rect.y += 16;
+            } else {
+                if rect.x + 8 <= rect.width as i32 && rect.y + 16 <= rect.height as i32 {
+                    renderer.char(
+                        rect.x,
+                        rect.y,
+                        c,
+                        theme.color("color", selector),
+                    );
+                }
+                rect.x += 8;
+            }
+        }
+    }
+
+    fn event(&self, _event: Event, _focused: bool, _redraw: &mut bool) -> bool {
+        _focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
+    }
+}

--- a/src/primitives/text_widget.rs
+++ b/src/primitives/text_widget.rs
@@ -6,55 +6,69 @@ use cell::CloneCell;
 use event::Event;
 use rect::Rect;
 use point::Point;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Place, Style};
-use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
+use widgets::{HorizontalPlacement, VerticalPlacement, Widget};
 
-pub struct Text {
+pub struct TextWidget {
     pub rect: Cell<Rect>,
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
 }
 
-impl Text {
+impl TextWidget {
     pub fn new() -> Arc<Self> {
-        Arc::new(Text {
+        let text_widget = Arc::new(TextWidget {
             rect: Cell::new(Rect::new(0, 0, 0, 16)),
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("Text"))),
             text: CloneCell::new(String::new()),
-        })
+        });
+
+        let text_widget_clone = text_widget.clone();
+        text_widget.text.on_changed(move |value: String| {
+            text_widget_clone.adjust_width(value.len() as u32);
+        });
+
+        text_widget
     }
 
     pub fn text<S: Into<String>>(&self, text: S) -> &Self {
         self.text.set(text.into());
-        self.adjust_width();
+        self.adjust_width(self.text.get().len() as u32);
         self
     }
 
-    fn adjust_width(&self) {
+    pub fn inner_text(&self) -> &CloneCell<String> {
+        &self.text
+    }
+
+    fn adjust_width(&self, text_len: u32) {
         let mut rect = self.rect.get();
-        rect.width =  self.text.get().len() as u32 * 8;
+        rect.width = text_len * 8;
         self.rect.set(rect);
     }
 }
 
-impl Place for Text {}
+impl Place for TextWidget {}
 
-impl Style for Text {
+impl Style for TextWidget {
     fn selector(&self) -> &CloneCell<Selector> {
         &self.selector
     }
 }
 
-impl Widget for Text {
+impl Widget for TextWidget {
     fn name(&self) -> &str {
         "Text"
     }
@@ -71,30 +85,37 @@ impl Widget for Text {
         &self.horizontal_placement
     }
 
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
+    }
+
     fn local_position(&self) -> &Cell<Point> {
         &self.local_position
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
-        let mut rect = self.rect().get();
+        let rect = self.rect().get();
+        let mut current_rect = self.rect().get();
         let x = rect.x;
         let selector = &self.selector().get();
         let text = self.text.get();
-       
+
         for c in text.chars() {
             if c == '\n' {
-                rect.x = x;
-                rect.y += 16;
+                current_rect.x = x;
+                current_rect.y += 16;
             } else {
-                if rect.x + 8 <= rect.width as i32 && rect.y + 16 <= rect.height as i32 {
+                if current_rect.x + 8 <= rect.x + rect.width as i32
+                    && current_rect.y + 16 <= rect.y + rect.height as i32
+                {
                     renderer.char(
-                        rect.x,
-                        rect.y,
+                        current_rect.x,
+                        current_rect.y,
                         c,
                         theme.color("color", selector),
                     );
                 }
-                rect.x += 8;
+                current_rect.x += 8;
             }
         }
     }

--- a/src/thickness.rs
+++ b/src/thickness.rs
@@ -1,0 +1,19 @@
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Thickness {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+impl Thickness {
+    pub fn new(left: i32, top: i32, right: i32, bottom: i32) -> Self {
+        Thickness {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+}

--- a/src/traits/place.rs
+++ b/src/traits/place.rs
@@ -3,9 +3,14 @@ use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 pub trait Place: Sized + Widget {
     fn position(&self, x: i32, y: i32) -> &Self {
         let mut position = self.local_position().get();
+        let mut rect = self.rect().get();
         position.x = x;
         position.y = y;
+        rect.x = x;
+        rect.y = y;
         self.local_position().set(position);
+        self.rect().set(rect);
+        self.arrange();
         self
     }
 
@@ -14,12 +19,14 @@ pub trait Place: Sized + Widget {
         rect.width = width;
         rect.height = height;
         self.rect().set(rect);
+        self.arrange();
         self
     }
 
      fn placement(&self, vertical_placement: VerticalPlacement, horizontal_placement: HorizontalPlacement) -> &Self {
         self.vertical_placement().set(vertical_placement);
         self.horizontal_placement().set(horizontal_placement);
+        self.arrange();
         self
     }
 }

--- a/src/traits/place.rs
+++ b/src/traits/place.rs
@@ -1,11 +1,11 @@
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub trait Place: Sized + Widget {
     fn position(&self, x: i32, y: i32) -> &Self {
-        let mut rect = self.rect().get();
-        rect.x = x;
-        rect.y = y;
-        self.rect().set(rect);
+        let mut position = self.local_position().get();
+        position.x = x;
+        position.y = y;
+        self.local_position().set(position);
         self
     }
 
@@ -14,6 +14,12 @@ pub trait Place: Sized + Widget {
         rect.width = width;
         rect.height = height;
         self.rect().set(rect);
+        self
+    }
+
+     fn placement(&self, vertical_placement: VerticalPlacement, horizontal_placement: HorizontalPlacement) -> &Self {
+        self.vertical_placement().set(vertical_placement);
+        self.horizontal_placement().set(horizontal_placement);
         self
     }
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -9,10 +9,14 @@ use point::Point;
 use rect::Rect;
 use theme::{Selector, Theme};
 use traits::{Click, Place, Text, Style};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub struct Button {
     pub rect: Cell<Rect>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_offset: Cell<Point>,
@@ -25,6 +29,10 @@ impl Button {
     pub fn new() -> Arc<Self> {
         Arc::new(Button {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("button"))),
             text: CloneCell::new(String::new()),
             text_offset: Cell::new(Point::default()),
@@ -75,6 +83,18 @@ impl Widget for Button {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -153,5 +173,9 @@ impl Widget for Button {
         }
 
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -7,6 +7,7 @@ use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Click, Place, Text, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -17,6 +18,7 @@ pub struct Button {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_offset: Cell<Point>,
@@ -32,6 +34,7 @@ impl Button {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("button"))),
             text: CloneCell::new(String::new()),
@@ -91,6 +94,10 @@ impl Widget for Button {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {

--- a/src/widgets/combo_box.rs
+++ b/src/widgets/combo_box.rs
@@ -5,7 +5,8 @@ use orbimage;
 use orbclient;
 
 use cell::{CheckSet, CloneCell};
-use widgets::{Image, Widget};
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
+use primitives::Image;
 use draw::draw_box;
 use event::Event;
 use rect::Rect;
@@ -18,6 +19,10 @@ static TOGGLE_ICON_ACTIVE: &'static [u8; 706] = include_bytes!("../../res/icon-d
 
 struct Entry {
     pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_offset: Cell<Point>,
@@ -31,6 +36,10 @@ impl Entry {
     fn new(text: &str, index: u32) -> Arc<Self> {
         Arc::new(Entry {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("combo-box-entry"))),
             text: CloneCell::new(String::from(text)),
             text_offset: Cell::new(Point::default()),
@@ -64,6 +73,19 @@ impl Widget for Entry {
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
     }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
         let rect = self.rect.get();
         let offset = self.text_offset.get();
@@ -140,10 +162,18 @@ impl Widget for Entry {
     fn name(&self) -> &str {
         "ComboBoxEntry"
     }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
+    }
 }
 
 pub struct ComboBox {
     pub rect: Cell<Rect>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
     pub selector: CloneCell<Selector>,
     pressed: Cell<bool>,
     activated: Cell<bool>,
@@ -170,6 +200,10 @@ impl ComboBox {
 
         Arc::new(ComboBox {
             rect: Cell::new(Rect::new(0, 0, 332, 28)),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("combo-box"))),
             pressed: Cell::new(false),
             activated: Cell::new(false),
@@ -252,6 +286,18 @@ impl Style for ComboBox {
 impl Widget for ComboBox {
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -420,6 +466,10 @@ impl Widget for ComboBox {
         }
 
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 
     fn name(&self) -> &str {

--- a/src/widgets/combo_box.rs
+++ b/src/widgets/combo_box.rs
@@ -11,6 +11,7 @@ use draw::draw_box;
 use event::Event;
 use rect::Rect;
 use point::Point;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Place, Style, Text};
 
@@ -22,6 +23,7 @@ struct Entry {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
@@ -39,6 +41,7 @@ impl Entry {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("combo-box-entry"))),
             text: CloneCell::new(String::from(text)),
@@ -84,6 +87,10 @@ impl Widget for Entry {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -174,6 +181,7 @@ pub struct ComboBox {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     pub selector: CloneCell<Selector>,
     pressed: Cell<bool>,
     activated: Cell<bool>,
@@ -203,6 +211,7 @@ impl ComboBox {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("combo-box"))),
             pressed: Cell::new(false),
@@ -298,6 +307,10 @@ impl Widget for ComboBox {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -7,6 +7,7 @@ use cell::CheckSet;
 use event::Event;
 use rect::Rect;
 use point::Point;
+use thickness::Thickness;
 use theme::{Theme};
 use traits::Place;
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -16,6 +17,7 @@ pub struct Grid {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     space_x: Cell<i32>,
     space_y: Cell<i32>,
@@ -33,6 +35,7 @@ impl Grid {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             space_x: Cell::new(0),
             space_y: Cell::new(0),
@@ -165,6 +168,10 @@ impl Widget for Grid {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -6,12 +6,17 @@ use std::sync::Arc;
 use cell::CheckSet;
 use event::Event;
 use rect::Rect;
+use point::Point;
 use theme::{Theme};
 use traits::Place;
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub struct Grid {
     pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     space_x: Cell<i32>,
     space_y: Cell<i32>,
     columns: Cell<usize>,
@@ -25,6 +30,10 @@ impl Grid {
     pub fn new() -> Arc<Self> {
         Arc::new(Grid {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             space_x: Cell::new(0),
             space_y: Cell::new(0),
             columns: Cell::new(0),
@@ -146,6 +155,18 @@ impl Widget for Grid {
         &self.rect
     }
 
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
         for (&(col, row), entry) in self.entries.borrow().iter() {
             entry.draw(renderer, self.focused.get() == Some((col, row)), theme);
@@ -166,5 +187,9 @@ impl Widget for Grid {
         }
 
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -7,6 +7,7 @@ use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Theme, Selector};
 use traits::{Click, Place, Text, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -16,6 +17,7 @@ pub struct Label {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     pub border: Cell<bool>,
@@ -33,6 +35,7 @@ impl Label {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("label"))),
             border: Cell::new(false),
@@ -97,6 +100,10 @@ impl Widget for Label {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -11,7 +11,7 @@ use point::Point;
 use rect::Rect;
 use theme::{Selector, Theme};
 use traits::{Click, Place, Style};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 use std::ops::Index;
 
 /// An entry in a list
@@ -59,6 +59,10 @@ impl Click for Entry {
 
 pub struct List {
     pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     v_scroll: Cell<i32>,
     current_height: Cell<u32>,
@@ -71,6 +75,10 @@ impl List {
     pub fn new() -> Arc<Self> {
         Arc::new(List {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("list"))),
             v_scroll: Cell::new(0),
             current_height: Cell::new(0),
@@ -170,6 +178,18 @@ impl Widget for List {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -307,6 +327,10 @@ impl Widget for List {
             _ => {}
         }
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -9,6 +9,7 @@ use cell::{CheckSet, CloneCell};
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Click, Place, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -62,6 +63,7 @@ pub struct List {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     pub selector: CloneCell<Selector>,
     v_scroll: Cell<i32>,
@@ -78,6 +80,7 @@ impl List {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("list"))),
             v_scroll: Cell::new(0),
@@ -186,6 +189,10 @@ impl Widget for List {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {

--- a/src/widgets/menu.rs
+++ b/src/widgets/menu.rs
@@ -10,10 +10,14 @@ use point::Point;
 use rect::Rect;
 use theme::{Theme, Selector};
 use traits::{Click, Place, Text, Style};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub struct Menu {
     pub rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
     text: CloneCell<String>,
     text_offset: Cell<Point>,
@@ -25,6 +29,10 @@ pub struct Menu {
 
 pub struct Separator {
     pub rect: Cell<Rect>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    local_position: Cell<Point>,
+    children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
 }
 
@@ -36,6 +44,10 @@ impl Menu {
     pub fn new<S: Into<String>>(name: S) -> Arc<Self> {
         Arc::new(Menu {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("menu"))),
             text: CloneCell::new(name.into()),
             text_offset: Cell::new(Point::default()),
@@ -111,6 +123,18 @@ impl Widget for Menu {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -216,10 +240,18 @@ impl Widget for Menu {
         }
         focused
     }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
+    }
 }
 
 pub struct Action {
     rect: Cell<Rect>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
+    children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
     text: CloneCell<String>,
     text_offset: Cell<Point>,
@@ -232,6 +264,10 @@ impl Action {
     pub fn new<S: Into<String>>(text: S) -> Arc<Self> {
         Arc::new(Action {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("action"))),
             text: CloneCell::new(text.into()),
             text_offset: Cell::new(Point::default()),
@@ -280,6 +316,18 @@ impl Widget for Action {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -349,6 +397,10 @@ impl Widget for Action {
 
         false
     }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
+    }
 }
 
 impl Entry for Action {
@@ -361,6 +413,10 @@ impl Separator {
     pub fn new() -> Arc<Self> {
         Arc::new(Separator {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("separator"))),
         })
     }
@@ -379,6 +435,18 @@ impl Widget for Separator {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -402,6 +470,10 @@ impl Widget for Separator {
             _ => (),
         }
         ignore_event
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }
 

--- a/src/widgets/menu.rs
+++ b/src/widgets/menu.rs
@@ -8,6 +8,7 @@ use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Theme, Selector};
 use traits::{Click, Place, Text, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -17,6 +18,7 @@ pub struct Menu {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
     text: CloneCell<String>,
@@ -31,6 +33,7 @@ pub struct Separator {
     pub rect: Cell<Rect>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     local_position: Cell<Point>,
     children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
@@ -47,6 +50,7 @@ impl Menu {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("menu"))),
             text: CloneCell::new(name.into()),
@@ -135,6 +139,10 @@ impl Widget for Menu {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -251,6 +259,7 @@ pub struct Action {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     children: RefCell<Vec<Arc<Widget>>>,
     selector: CloneCell<Selector>,
     text: CloneCell<String>,
@@ -267,6 +276,7 @@ impl Action {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("action"))),
             text: CloneCell::new(text.into()),
@@ -324,6 +334,10 @@ impl Widget for Action {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {
@@ -416,6 +430,7 @@ impl Separator {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("separator"))),
         })
@@ -447,6 +462,10 @@ impl Widget for Separator {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,34 +1,61 @@
 use orbclient::Renderer;
 use std::any::Any;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 
 use event::Event;
 use rect::Rect;
+use point::Point;
 use theme::Theme;
 
 pub use self::button::Button;
 pub use self::combo_box::ComboBox;
 pub use self::grid::Grid;
-pub use self::image::Image;
 pub use self::label::Label;
 pub use self::menu::{ Menu, Action, Separator };
 pub use self::progress_bar::ProgressBar;
 pub use self::text_box::TextBox;
 pub use self::list::{ List, Entry };
 
+pub use self::test_button::TestButton;
+
 mod button;
 mod combo_box;
 mod grid;
-mod image;
 mod label;
 mod menu;
 mod progress_bar;
 mod text_box;
 mod list;
 
+mod test_button;
+
+pub enum VerticalPlacement { 
+    Top,
+    Center,
+    Bottom,
+    Absolute,
+}
+
+pub enum HorizontalPlacement {
+    Left,
+    Center,
+    Right,
+    Absolute,
+}
+
 pub trait Widget : Any {
     fn rect(&self) -> &Cell<Rect>;
-    fn draw(&self, renderer: &mut Renderer, focused: bool, theme: &Theme);
-    fn event(&self, event: Event, focused: bool, redraw: &mut bool) -> bool;
+    fn local_position(&self) -> &Cell<Point>;
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement>;
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement>;
+    fn draw(&self, _renderer: &mut Renderer, _focused: bool, _theme: &Theme) {}
+    fn event(&self, _event: Event, _focused: bool, _redraw: &mut bool) -> bool {
+        _focused
+    }
     fn name(&self) -> &str;
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>>;
+    fn arrage(&self) {
+
+    }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -7,15 +7,16 @@ use event::Event;
 use rect::Rect;
 use point::Point;
 use theme::Theme;
+use thickness::Thickness;
 
 pub use self::button::Button;
 pub use self::combo_box::ComboBox;
 pub use self::grid::Grid;
 pub use self::label::Label;
-pub use self::menu::{ Menu, Action, Separator };
+pub use self::menu::{Action, Menu, Separator};
 pub use self::progress_bar::ProgressBar;
 pub use self::text_box::TextBox;
-pub use self::list::{ List, Entry };
+pub use self::list::{Entry, List};
 
 pub use self::test_button::TestButton;
 
@@ -30,32 +31,94 @@ mod list;
 
 mod test_button;
 
-pub enum VerticalPlacement { 
+#[derive(PartialEq, Copy, Clone)]
+pub enum VerticalPlacement {
     Top,
     Center,
     Bottom,
     Absolute,
+    Stretch,
 }
 
+#[derive(PartialEq, Copy, Clone)]
 pub enum HorizontalPlacement {
     Left,
     Center,
     Right,
     Absolute,
+    Stretch,
 }
 
-pub trait Widget : Any {
+pub trait Widget: Any {
     fn rect(&self) -> &Cell<Rect>;
     fn local_position(&self) -> &Cell<Point>;
     fn vertical_placement(&self) -> &Cell<VerticalPlacement>;
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement>;
+    fn margin(&self) -> &Cell<Thickness>;
     fn draw(&self, _renderer: &mut Renderer, _focused: bool, _theme: &Theme) {}
     fn event(&self, _event: Event, _focused: bool, _redraw: &mut bool) -> bool {
         _focused
     }
     fn name(&self) -> &str;
     fn children(&self) -> &RefCell<Vec<Arc<Widget>>>;
-    fn arrage(&self) {
+    fn add(&self, widget: Arc<Widget>) {
+        (*self.children().borrow_mut()).push(widget);
+    }
 
+    fn arrange(&self) {
+        let parent_rect = self.rect().get();
+
+        for child in &*self.children().borrow_mut() {
+            let mut child_rect = child.rect().get();
+            let child_position = child.local_position().get();
+            let margin = child.margin().get();
+
+            match child.vertical_placement().get() {
+                VerticalPlacement::Absolute => {
+                    child_rect.y = parent_rect.y + child_position.y;
+                }
+                VerticalPlacement::Stretch => {
+                    child_rect.height =
+                        parent_rect.height - margin.top as u32 - margin.bottom as u32;
+                    child_rect.y = parent_rect.y + margin.top;
+                }
+                VerticalPlacement::Top => {
+                    child_rect.y = parent_rect.y + margin.top;
+                }
+                VerticalPlacement::Center => {
+                    child_rect.y = parent_rect.y + parent_rect.height as i32 / 2
+                        - child_rect.height as i32 / 2;
+                }
+                VerticalPlacement::Bottom => {
+                    child_rect.y = parent_rect.y + parent_rect.height as i32 - margin.bottom
+                        - child_rect.height as i32;
+                }
+            }
+
+            match child.horizontal_placement().get() {
+                HorizontalPlacement::Absolute => {
+                    child_rect.x = parent_rect.x + child_position.x;
+                }
+                HorizontalPlacement::Stretch => {
+                    child_rect.width =
+                        parent_rect.width - margin.left as u32 - margin.right as u32;
+                    child_rect.x = parent_rect.x + margin.left;
+                }
+                HorizontalPlacement::Left => {
+                    child_rect.x = parent_rect.x + margin.left;
+                }
+                HorizontalPlacement::Center => {
+                    child_rect.x = parent_rect.x + parent_rect.width as i32 / 2
+                        - child_rect.width as i32 / 2;
+                }
+                HorizontalPlacement::Right => {
+                    child_rect.x = parent_rect.x + parent_rect.width as i32 - margin.right
+                        - child_rect.width as i32;
+                }
+            }
+
+            child.rect().set(child_rect);
+            child.arrange();
+        }
     }
 }

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -8,6 +8,7 @@ use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Theme, Selector};
 use traits::{Click, Place, Style};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -18,6 +19,7 @@ pub struct ProgressBar {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     pub selector: CloneCell<Selector>,
     pub value: Cell<i32>,
     pub minimum: i32,
@@ -33,6 +35,7 @@ impl ProgressBar {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("progress-bar"))),
             value: Cell::new(0),
@@ -85,6 +88,10 @@ impl Widget for ProgressBar {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn local_position(&self) -> &Cell<Point> {

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -10,10 +10,14 @@ use point::Point;
 use rect::Rect;
 use theme::{Theme, Selector};
 use traits::{Click, Place, Style};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 pub struct ProgressBar {
     pub rect: Cell<Rect>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
     pub selector: CloneCell<Selector>,
     pub value: Cell<i32>,
     pub minimum: i32,
@@ -26,6 +30,10 @@ impl ProgressBar {
     pub fn new() -> Arc<Self> {
         Arc::new(ProgressBar {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("progress-bar"))),
             value: Cell::new(0),
             minimum: 0,
@@ -69,6 +77,18 @@ impl Widget for ProgressBar {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
     }
 
     fn draw(&self, renderer: &mut Renderer, _focused: bool, theme: &Theme) {
@@ -128,5 +148,9 @@ impl Widget for ProgressBar {
         }
 
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -10,6 +10,7 @@ use draw::draw_box;
 use event::Event;
 use point::Point;
 use rect::Rect;
+use thickness::Thickness;
 use theme::{Selector, Theme};
 use traits::{Click, Enter, EventFilter, Place, Style, Text};
 use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
@@ -37,6 +38,7 @@ pub struct TextBox {
     local_position: Cell<Point>,
     vertical_placement: Cell<VerticalPlacement>,
     horizontal_placement: Cell<HorizontalPlacement>,
+    margin: Cell<Thickness>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_i: Cell<usize>,
@@ -66,6 +68,7 @@ impl TextBox {
             local_position: Cell::new(Point::new(0, 0)),
             vertical_placement: Cell::new(VerticalPlacement::Absolute),
             horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            margin: Cell::new(Thickness::default()),
             children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("text-box"))),
             text: CloneCell::new(String::new()),
@@ -177,6 +180,10 @@ impl Widget for TextBox {
 
     fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
         &self.horizontal_placement
+    }
+
+    fn margin(&self) -> &Cell<Thickness> {
+        &self.margin
     }
 
     fn draw(&self, renderer: &mut Renderer, focused: bool, theme: &Theme) {

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -12,7 +12,7 @@ use point::Point;
 use rect::Rect;
 use theme::{Selector, Theme};
 use traits::{Click, Enter, EventFilter, Place, Style, Text};
-use widgets::Widget;
+use widgets::{Widget, VerticalPlacement, HorizontalPlacement};
 
 /// Find next character index
 fn next_i(text: &str, text_i: usize) -> usize {
@@ -33,6 +33,10 @@ fn prev_i(text: &str, text_i: usize) -> usize {
 
 pub struct TextBox {
     pub rect: Cell<Rect>,
+    children: RefCell<Vec<Arc<Widget>>>,
+    local_position: Cell<Point>,
+    vertical_placement: Cell<VerticalPlacement>,
+    horizontal_placement: Cell<HorizontalPlacement>,
     pub selector: CloneCell<Selector>,
     pub text: CloneCell<String>,
     pub text_i: Cell<usize>,
@@ -59,6 +63,10 @@ impl TextBox {
     pub fn new() -> Arc<Self> {
         Arc::new(TextBox {
             rect: Cell::new(Rect::default()),
+            local_position: Cell::new(Point::new(0, 0)),
+            vertical_placement: Cell::new(VerticalPlacement::Absolute),
+            horizontal_placement: Cell::new(HorizontalPlacement::Absolute),
+            children: RefCell::new(vec![]),
             selector: CloneCell::new(Selector::new(Some("text-box"))),
             text: CloneCell::new(String::new()),
             text_i: Cell::new(0),
@@ -157,6 +165,18 @@ impl Widget for TextBox {
 
     fn rect(&self) -> &Cell<Rect> {
         &self.rect
+    }
+
+    fn local_position(&self) -> &Cell<Point> {
+        &self.local_position
+    }
+
+    fn vertical_placement(&self) -> &Cell<VerticalPlacement> {
+        &self.vertical_placement
+    }
+
+    fn horizontal_placement(&self) -> &Cell<HorizontalPlacement> {
+        &self.horizontal_placement
     }
 
     fn draw(&self, renderer: &mut Renderer, focused: bool, theme: &Theme) {
@@ -560,5 +580,9 @@ impl Widget for TextBox {
             }
         }
         focused
+    }
+
+    fn children(&self) -> &RefCell<Vec<Arc<Widget>>> {
+        &self.children
     }
 }


### PR DESCRIPTION
Start implementation of a widget children tree system #72 . Widget should be able to build from child widgets. It's no more necessary to write draw (render) code for new widgets, but still possible. This PR should also be compatible to the current orbutils sources.

Features contained in this PR:

**Widget**
* children vector
* placement (enum)
* default arrangement of children
* local position

**Other features**

* base implementation of focus manager
* add binding (change) callbacks to CloneCell
* TestButton: used to test the children widget thing (will be removed)

**Open**

* children using selector of parent
* parent member for children
* Improved event system with preview events #73 
* refactoring examples
