### PR TITLE
Fix up calcurator example: show only 9 digits to fit in the display

### DIFF
--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -65,7 +65,8 @@ impl MainViewState {
             }
         }
 
-        ctx.widget().set("text", String16::from(result.to_string()));
+        ctx.widget()
+            .set("text", String16::from(format!("{:.9}", result)));
         self.left_side = Some(result);
         self.right_side = None;
     }


### PR DESCRIPTION
Here is screenshot of result of 22/7

before 

![image](https://user-images.githubusercontent.com/4434568/70533717-f8214700-1b9c-11ea-817b-b3ad1a3ce619.png)

after
![image](https://user-images.githubusercontent.com/4434568/70533667-df189600-1b9c-11ea-9f08-ac2b62992951.png)
