### PR TITLE
> fix calculator result display overflow

### DIFF
--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -66,7 +66,7 @@ impl MainViewState {
         }
 
         ctx.widget()
-            .set("text", String16::from(format!("{:.9}", result)));
+            .set("text", String16::from(format!("{}", result)));
         self.left_side = Some(result);
         self.right_side = None;
     }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7303612/70689843-54e14680-1cf0-11ea-917b-15a0838c2f40.png)


After:
![image](https://user-images.githubusercontent.com/7303612/70689877-6aef0700-1cf0-11ea-9ac4-129d5b54ccb5.png)

