### PR TITLE
Support non-BMP in String16::push

### DIFF
--- a/crates/utils/src/string16.rs
+++ b/crates/utils/src/string16.rs
@@ -50,9 +50,13 @@ impl String16 {
         }
     }
 
-    /// Appends a given string slice onto the end of this `String16`.
+    /// Appends a given char onto the end of this `String16`.
     pub fn push(&mut self, ch: char) {
-        self.utf16.push(ch as u16)
+        let mut buf = [0; 2];
+
+        for part in ch.encode_utf16(&mut buf) {
+            self.utf16.push(*part)
+        }
     }
 
     /// Removes a [`char`] from this `String16` at a byte position and returns it.
@@ -133,5 +137,18 @@ mod tests {
 
         let string16 = String16::from("World");
         assert_eq!(string16.len(), 5);
+    }
+
+    #[test]
+    fn push() {
+        // Single-u16 encoded char
+        let mut string16 = String16::from("Fo");
+        string16.push('o');
+        assert_eq!(string16, String16::from("Foo"));
+
+        // Two-u16 encoded char
+        let mut string16 = String16::from("Bar");
+        string16.push('𝕊');
+        assert_eq!(string16, String16::from("Bar𝕊"));
     }
 }


### PR DESCRIPTION
Fix for #120.

Looking at the other methods, other changes will probably be required to actually correctly support non-BMP chars, but I focused on the one I reported for my first PR here.