### PR TITLE
Fix borderless on mac

### DIFF
--- a/crates/shell/src/minifb/mod.rs
+++ b/crates/shell/src/minifb/mod.rs
@@ -443,6 +443,7 @@ where
         let window_options = minifb::WindowOptions {
             resize: self.resizeable,
             borderless: self.borderless,
+            title: !self.borderless,
             scale_mode: minifb::ScaleMode::UpperLeft,
             ..Default::default()
         };


### PR DESCRIPTION
minifb needs `title = false` to achieve a true borderless window on macos.

This PR sets `title = false` if `borderless == true`

We could also expose the title flag or just check if the title is an empty string and then set `title = !borderless && title.len() == 0`