### PR TITLE
Fix stack layout to use the max height/width

### DIFF
--- a/crates/api/src/layout/stack.rs
+++ b/crates/api/src/layout/stack.rs
@@ -311,10 +311,10 @@ fn accumulate_desired_size(
     match orientation {
         Orientation::Horizontal => {
             desired_size.0 += width;
-            desired_size.1 = height;
+            desired_size.1 = desired_size.1.max(height);
         }
         Orientation::Vertical => {
-            desired_size.0 = width;
+            desired_size.0 = desired_size.0.max(width);
             desired_size.1 += height;
         }
     }


### PR DESCRIPTION
Currently the StackLayout uses the height/width in cross-dimension from the last child.
This PR changes that to use the max height/width in cross-dimension
Fixes #168