### PR TITLE
Fixed typos in doc comments

### DIFF
--- a/crates/api/src/event/key.rs
+++ b/crates/api/src/event/key.rs
@@ -56,7 +56,7 @@ pub trait KeyDownHandler: Sized + Widget {
         })
     }
 
-    // Handles events triggered by a specific key.
+    /// Handles events triggered by a specific key.
     fn on_key_down_key<H: Fn() -> bool + 'static>(self, key: Key, handler: H) -> Self {
         self.on_key_down(
             move |_, event| {

--- a/crates/api/src/event/mod.rs
+++ b/crates/api/src/event/mod.rs
@@ -22,7 +22,7 @@ mod mouse;
 mod system;
 mod window;
 
-/// Defines the strategy a event moves through the tree.
+/// Defines the strategy of an event how it moves through the tree.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EventStrategy {
     // /// From root to leaf.
@@ -30,7 +30,7 @@ pub enum EventStrategy {
     /// From leaf to root.
     BottomUp,
 
-    /// Occures direct.
+    /// Occurs direct.
     Direct,
 }
 

--- a/crates/api/src/event/mouse.rs
+++ b/crates/api/src/event/mouse.rs
@@ -241,7 +241,7 @@ pub trait MouseHandler: Sized + Widget {
         })
     }
 
-    /// Insert a mouse handler for global up event.s
+    /// Insert a mouse handler for global up event.
     fn on_global_mouse_up<H: Fn(&mut StatesContext, Point) + 'static>(self, handler: H) -> Self {
         self.insert_handler(GlobalMouseUpEventHandler {
             handler: Rc::new(handler),

--- a/crates/api/src/layout/grid.rs
+++ b/crates/api/src/layout/grid.rs
@@ -9,8 +9,8 @@ use crate::{prelude::*, render::RenderContext2D, tree::Tree, utils::prelude::*};
 
 use super::{component, component_try_mut, Layout};
 
-/// Orders its children in a grid layout with columns and rows. If now columns and rows are defined
-/// the gird layout could also be used as alignment layout.
+/// Orders its children in a grid layout with columns and rows. If no columns and rows are defined
+/// the grid layout could also be used as an alignment layout.
 #[derive(Default)]
 pub struct GridLayout {
     desired_size: RefCell<DirtySize>,

--- a/crates/api/src/layout/mod.rs
+++ b/crates/api/src/layout/mod.rs
@@ -34,7 +34,7 @@ pub trait Layout: Any {
         theme: &ThemeValue,
     ) -> DirtySize;
 
-    /// Arranges an sizes the children.
+    /// Arranges and sizes the children.
     fn arrange(
         &self,
         render_context_2_d: &mut RenderContext2D,

--- a/crates/api/src/properties/layout/constraint.rs
+++ b/crates/api/src/properties/layout/constraint.rs
@@ -118,7 +118,7 @@ impl Constraint {
         ConstraintBuilder::new()
     }
 
-    // Gets width.
+    /// Gets width.
     pub fn width(&self) -> f64 {
         self.width
     }

--- a/crates/api/src/properties/layout/row.rs
+++ b/crates/api/src/properties/layout/row.rs
@@ -176,12 +176,12 @@ impl Rows {
         self.0.is_empty()
     }
 
-    /// Returns a reference to an row.
+    /// Returns a reference to a row.
     pub fn get(&self, row: usize) -> Option<&Row> {
         self.0.get(row)
     }
 
-    /// Returns a mutable reference to an row.
+    /// Returns a mutable reference to a row.
     pub fn get_mut(&mut self, row: usize) -> Option<&mut Row> {
         self.0.get_mut(row)
     }

--- a/crates/api/src/properties/mod.rs
+++ b/crates/api/src/properties/mod.rs
@@ -1,4 +1,4 @@
-//! This sub module contains extra structs used as widget proerties.
+//! This sub module contains extra structs used as widget properties.
 
 use std::{collections::HashSet, fmt::Debug};
 
@@ -11,7 +11,7 @@ use crate::{css_engine, prelude::*, render, utils};
 mod layout;
 mod widget;
 
-/// Used to the a property of a widget.
+/// Get the property of a widget.
 pub fn get_property<T>(key: &str, entity: Entity, store: &StringComponentStore) -> T
 where
     T: Clone + Component,

--- a/crates/api/src/services/settings.rs
+++ b/crates/api/src/services/settings.rs
@@ -21,7 +21,7 @@ use ron::ser::{to_string_pretty, PrettyConfig};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// `Settings` represents a global settings service that could be use to serialize and deserialize
-/// data in the `ron` file format. Settings are stored in the user settings directory (depending on the operation system)
+/// data in the `ron` file format. Settings are stored in the user settings directory (depending on the operating system)
 /// under the a folder with the given application name.
 pub struct Settings {
     app_name: Box<str>,

--- a/crates/api/src/systems/layout_system.rs
+++ b/crates/api/src/systems/layout_system.rs
@@ -4,7 +4,7 @@ use dces::prelude::{Entity, EntityComponentManager, System};
 
 use crate::{css_engine::*, prelude::*, shell::WindowShell, tree::Tree, utils::*};
 
-/// The `LayoutSystem` builds per iteration the layout of the current ui. The layout parts are calulated by the layout objects of layout widgets.
+/// The `LayoutSystem` builds per iteration the layout of the current ui. The layout parts are calculated by the layout objects of layout widgets.
 pub struct LayoutSystem {
     pub layouts: Rc<RefCell<BTreeMap<Entity, Box<dyn Layout>>>>,
     pub shell: Rc<RefCell<WindowShell<WindowAdapter>>>,

--- a/crates/api/src/systems/mod.rs
+++ b/crates/api/src/systems/mod.rs
@@ -1,5 +1,5 @@
 //! Contains all system used in OrbTk. Systems are meant as systems in OrbTks Entity Component System.
-//! The are used for event handling, layouting and drawing.
+//! These are used for event handling, building layout and drawing.
 
 pub use self::cleanup_system::*;
 pub use self::event_state_system::*;

--- a/crates/api/src/widget/build_context.rs
+++ b/crates/api/src/widget/build_context.rs
@@ -49,8 +49,8 @@ impl<'a> BuildContext<'a> {
             .unwrap();
     }
 
-    /// Appends a child to to overlay (on the top of the main tree). If the overlay does not exists an error
-    /// will be returned.
+    /// Appends a child to overlay (on the top of the main tree). If the overlay does not exists an
+    /// error will be returned.
     pub fn append_child_to_overlay(&mut self, child: Entity) -> Result<(), String> {
         if let Some(overlay) = self.ecm.entity_store().overlay {
             self.append_child(overlay.into(), child);
@@ -132,7 +132,7 @@ impl<'a> BuildContext<'a> {
             .insert(widget, render_object);
     }
 
-    /// Registers a event handler with a widget.
+    /// Registers an event handler with a widget.
     pub fn register_handler(&mut self, widget: Entity, handler: Rc<dyn EventHandler>) {
         if !self.handlers.contains_key(&widget) {
             self.handlers.insert(widget, vec![]);

--- a/crates/api/src/widget/context.rs
+++ b/crates/api/src/widget/context.rs
@@ -90,7 +90,7 @@ impl<'a> Context<'a> {
     }
 
     /// Returns a child of the widget of the current state referenced by css `id`.
-    /// If the no id is defined its panics.
+    /// If there is no id defined, it will panic.
     pub fn child<'b>(&mut self, id: impl Into<&'b str>) -> WidgetContainer<'_> {
         self.entity_of_child(id)
             .map(move |child| self.get_widget(child))
@@ -98,7 +98,7 @@ impl<'a> Context<'a> {
     }
 
     /// Returns a child of the widget of the current state referenced by css `id`.
-    /// If the no id is defined None will returned.
+    /// If there is no id defined, None will returned.
     pub fn try_child<'b>(&mut self, id: impl Into<&'b str>) -> Option<WidgetContainer<'_>> {
         self.entity_of_child(id)
             .map(move |child| self.get_widget(child))
@@ -111,7 +111,7 @@ impl<'a> Context<'a> {
         self.get_widget(entity)
     }
 
-    // Returns the parent of the current widget.
+    /// Returns the parent of the current widget.
     /// If the current widget is the root None will be returned.
     pub fn try_parent(&mut self) -> Option<WidgetContainer<'_>> {
         if self.ecm.entity_store().parent[&self.entity] == None {
@@ -152,7 +152,7 @@ impl<'a> Context<'a> {
     }
 
     /// Returns a parent of the widget of the current state referenced by css `id`.
-    /// If the no id is defined None will returned.
+    /// If there is no id defined None will be returned.
     pub fn try_parent_from_id<'b>(
         &mut self,
         id: impl Into<&'b str>,
@@ -221,8 +221,8 @@ impl<'a> Context<'a> {
         bctx.append_child(parent, child);
     }
 
-    /// Appends a child widget to to overlay (on the top of the main tree). If the overlay does not exists an error
-    /// will be returned.
+    /// Appends a child widget to overlay (on the top of the main tree). If the overlay does not
+    /// exists an error will be returned.
     pub fn append_child_to_overlay<W: Widget>(&mut self, child: W) -> Result<(), String> {
         if let Some(overlay) = self.ecm.entity_store().overlay {
             let bctx = &mut self.build_context();
@@ -239,8 +239,8 @@ impl<'a> Context<'a> {
         self.build_context().append_child(parent, child)
     }
 
-    /// Appends a child entity to to overlay (on the top of the main tree). If the overlay does not exists an error
-    /// will be returned.
+    /// Appends a child entity to overlay (on the top of the main tree). If the overlay does not
+    /// exists an error will be returned.
     pub fn append_child_entity_to_overlay(&mut self, child: Entity) -> Result<(), String> {
         if let Some(overlay) = self.ecm.entity_store().overlay {
             self.append_child_entity_to(overlay.into(), child);
@@ -339,7 +339,7 @@ impl<'a> Context<'a> {
     }
 
     /// Returns the entity of the parent referenced by css `element`.
-    /// If the no id is defined None will returned.
+    /// If there is no id defined None will be returned.
     pub fn parent_entity_by_element<'b>(&mut self, element: impl Into<&'b str>) -> Option<Entity> {
         let mut current = self.entity;
         let element = element.into();
@@ -450,7 +450,7 @@ impl<'a> Context<'a> {
         self.window_shell.render_context_2_d()
     }
 
-    /// Gets a a new sender to send request to the window shell.
+    /// Gets a new sender to send request to the window shell.
     pub fn request_sender(&self) -> Sender<ShellRequest> {
         self.window_shell.request_sender()
     }

--- a/crates/api/src/widget/mod.rs
+++ b/crates/api/src/widget/mod.rs
@@ -46,7 +46,7 @@ pub enum ParentType {
     /// Only one child could be added to the widget.
     Single,
 
-    /// Multiple children could be added tot the widget.
+    /// Multiple children could be added to the widget.
     Multi,
 }
 
@@ -61,6 +61,6 @@ pub trait Widget: Template {
     /// Inerts a new event handler.
     fn insert_handler(self, handler: impl Into<Rc<dyn EventHandler>>) -> Self;
 
-    /// Appends a child ot the widget.
+    /// Appends a child to the widget.
     fn child(self, child: Entity) -> Self;
 }

--- a/crates/api/src/widget/mod.rs
+++ b/crates/api/src/widget/mod.rs
@@ -40,7 +40,7 @@ pub fn remove_selector_from_widget(pseudo_class: &str, widget: &mut WidgetContai
 
 /// Used to define the `parent_type`of a widget.
 pub enum ParentType {
-    /// None children could add to the widget.
+    /// No children could be added to the widget.
     None,
 
     /// Only one child could be added to the widget.


### PR DESCRIPTION
I fixed two typos in doc comments during reading the source code.
Then i checked the crates::api, more to come