### PR TITLE
Add a basic overlap avoidance algorithm to border-radius

### DIFF
--- a/crates/api/src/render_object/rectangle.rs
+++ b/crates/api/src/render_object/rectangle.rs
@@ -127,6 +127,23 @@ impl RectangleRenderObject {
             render_context_2_d.stroke();
         }
     }
+
+    pub(crate) fn ensure_no_corner_overlap(
+        border_radius: &mut f64,
+        bounds: Rectangle
+    ) {
+        let mut ratio = 1.0;
+        let sum = 2.0 * *border_radius;
+        if bounds.width() < sum {
+            ratio = f64::min(ratio, bounds.width() / sum);
+        }
+        if bounds.height() < sum {
+            ratio = f64::min(ratio, bounds.height() / sum);
+}
+        if ratio < 1. {
+            *border_radius *= ratio;
+        }
+    }
 }
 
 impl Into<Box<dyn RenderObject>> for RectangleRenderObject {
@@ -165,8 +182,9 @@ impl RenderObject for RectangleRenderObject {
             || border_thickness.bottom > 0.0;
 
         ctx.render_context_2_d().begin_path();
-
-        if bounds.width() == bounds.height() && border_radius >= bounds.width() / 2.0 {
+        let mut border_radius = border_radius;
+        Self::ensure_no_corner_overlap(&mut border_radius, bounds);
+        if bounds.width() == bounds.height() {
             if !has_thickness {
                 self.render_circle(
                     ctx.render_context_2_d(),


### PR DESCRIPTION
Currently the border-radius of one corner can overlap with another corner.

ATM in this cases `render_circle `might be called which results in circles larger than the width and height