### PR TITLE
Docs typos fix

### DIFF
--- a/crates/css-engine/src/lib.rs
+++ b/crates/css-engine/src/lib.rs
@@ -1,7 +1,6 @@
 /*!
 
-This crate provides functions to load a css files as theme and access it properties with
-selectors.
+This crate provides functions to load a css file as theme and access its properties with selectors.
 
 This crate depends on the orbtk_utils crate.
 

--- a/crates/css-engine/src/theme.rs
+++ b/crates/css-engine/src/theme.rs
@@ -298,7 +298,7 @@ impl<'i> cssparser::QualifiedRuleParser<'i> for RuleParser {
                         ParseError::Basic(ref e) => eprintln!("{:?}", e),
                         ParseError::Custom(ref e) => eprintln!("{:?}", e),
                     }
-                    println!("Error occured in `{}`", input.slice(e.span.clone()));
+                    println!("Error occurred in `{}`", input.slice(e.span.clone()));
                 }
             }
         }
@@ -524,7 +524,7 @@ pub fn parse(s: &str) -> Vec<Rule> {
                     ParseError::Basic(ref e) => eprintln!("{:?}", e),
                     ParseError::Custom(ref e) => eprintln!("{:?}", e),
                 }
-                println!("Error occured in `{}`", parser.slice(e.span.clone()));
+                println!("Error occurred in `{}`", parser.slice(e.span.clone()));
             }
         }
     }

--- a/crates/render/src/concurrent/mod.rs
+++ b/crates/render/src/concurrent/mod.rs
@@ -29,7 +29,7 @@ enum RenderTask {
         font_file: &'static [u8],
     },
 
-    // Mutli tasks
+    // Multi tasks
     FillRect {
         x: f64,
         y: f64,
@@ -451,7 +451,8 @@ impl RenderContext2D {
 
     // Rectangles
 
-    /// Draws a filled rectangle whose starting point is at the coordinates {x, y} with the specified width and height and whose style is determined by the fillStyle attribute.
+    /// Draws a filled rectangle whose starting point is at the coordinates {x, y} with the
+    /// specified width and height and whose style is determined by the fillStyle attribute.
     pub fn fill_rect(&mut self, x: f64, y: f64, width: f64, height: f64) {
         self.tasks.push(RenderTask::FillRect {
             x,
@@ -514,7 +515,8 @@ impl RenderContext2D {
         self.tasks.push(RenderTask::BeginPath());
     }
 
-    /// Attempts to add a straight line from the current point to the start of the current sub-path. If the shape has already been closed or has only one point, this function does nothing.
+    /// Attempts to add a straight line from the current point to the start of the current sub-path.
+    /// If the shape has already been closed or has only one point, this function does nothing.
     pub fn close_path(&mut self) {
         self.tasks.push(RenderTask::ClosePath());
         self.send_tasks();
@@ -529,7 +531,8 @@ impl RenderContext2D {
         });
     }
 
-    /// Creates a circular arc centered at (x, y) with a radius of radius. The path starts at startAngle and ends at endAngle.
+    /// Creates a circular arc centered at (x, y) with a radius of radius.
+    /// The path starts at startAngle and ends at endAngle.
     pub fn arc(&mut self, x: f64, y: f64, radius: f64, start_angle: f64, end_angle: f64) {
         self.tasks.push(RenderTask::Arc {
             x,
@@ -546,7 +549,8 @@ impl RenderContext2D {
         self.tasks.push(RenderTask::MoveTo { x, y });
     }
 
-    /// Adds a straight line to the current sub-path by connecting the sub-path's last point to the specified {x, y} coordinates.
+    /// Adds a straight line to the current sub-path by connecting the sub-path's last point to
+    /// the specified {x, y} coordinates.
     pub fn line_to(&mut self, x: f64, y: f64) {
         self.tasks.push(RenderTask::LineTo { x, y });
     }
@@ -557,7 +561,10 @@ impl RenderContext2D {
             .push(RenderTask::QuadraticCurveTo { cpx, cpy, x, y });
     }
 
-    /// Adds a cubic Bézier curve to the current sub-path. It requires three points: the first two are control points and the third one is the end point. The starting point is the latest point in the current path, which can be changed using MoveTo{} before creating the Bézier curve.
+    /// Adds a cubic Bézier curve to the current sub-path. It requires three points:
+    /// the first two are control points and the third one is the end point.
+    /// The starting point is the latest point in the current path, which can be changed using
+    /// MoveTo{} before creating the Bézier curve.
     pub fn bezier_curve_to(&mut self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
         self.tasks.push(RenderTask::BesierCurveTo {
             cp1x,
@@ -623,7 +630,8 @@ impl RenderContext2D {
             .expect("Could not send draw_pipeline to render thread.");
     }
 
-    /// Creates a clipping path from the current sub-paths. Everything drawn after clip() is called appears inside the clipping path only.
+    /// Creates a clipping path from the current sub-paths.
+    /// Everything drawn after clip() is called appears inside the clipping path only.
     pub fn clip(&mut self) {
         self.tasks.push(RenderTask::Clip());
     }
@@ -640,7 +648,7 @@ impl RenderContext2D {
         self.tasks.push(RenderTask::SetAlpha { alpha });
     }
 
-    /// Specific the font family.
+    /// Specifies the font family.
     pub fn set_font_family(&mut self, family: impl Into<String>) {
         let family = family.into();
         self.tasks.push(RenderTask::SetFontFamily { family });
@@ -665,7 +673,7 @@ impl RenderContext2D {
 
     // Transformations
 
-    /// Sets the tranformation.
+    /// Sets the transformation.
     pub fn set_transform(
         &mut self,
         h_scaling: f64,
@@ -692,7 +700,8 @@ impl RenderContext2D {
         self.tasks.push(RenderTask::Save());
     }
 
-    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack. If there is no saved state, this method does nothing.
+    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack.
+    /// If there is no saved state, this method does nothing.
     pub fn restore(&mut self) {
         self.tasks.push(RenderTask::Restore());
     }

--- a/crates/render/src/raqote/mod.rs
+++ b/crates/render/src/raqote/mod.rs
@@ -226,7 +226,9 @@ impl RenderContext2D {
         self.path = path_builder.finish();
     }
 
-    /// Adds a cubic Bézier curve to the current sub-path. It requires three points: the first two are control points and the third one is the end point. The starting point is the latest point in the current path, which can be changed using MoveTo{} before creating the Bézier curve.
+    /// Adds a cubic Bézier curve to the current sub-path.
+    /// It requires three points: the first two are control points and the third one is the end point.
+    /// The starting point is the latest point in the current path, which can be changed using MoveTo{} before creating the Bézier curve.
     pub fn bezier_curve_to(&mut self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
         let mut path_builder = raqote::PathBuilder::from(self.path.clone());
         path_builder.cubic_to(
@@ -335,7 +337,7 @@ impl RenderContext2D {
         self.config.alpha = alpha;
     }
 
-    /// Specific the font family.
+    /// Specifies the font family.
     pub fn set_font_family(&mut self, family: impl Into<String>) {
         self.config.font_config.family = family.into();
     }
@@ -359,7 +361,7 @@ impl RenderContext2D {
 
     // Transformations
 
-    /// Sets the tranformation.
+    /// Sets the transformation.
     pub fn set_transform(
         &mut self,
         h_scaling: f64,
@@ -387,7 +389,8 @@ impl RenderContext2D {
         self.saved_config = Some(self.config.clone());
     }
 
-    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack. If there is no saved state, this method does nothing.
+    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack.
+    /// If there is no saved state, this method does nothing.
     pub fn restore(&mut self) {
         self.clip = false;
         self.clip_rect = None;

--- a/crates/render/src/web/image.rs
+++ b/crates/render/src/web/image.rs
@@ -14,7 +14,7 @@ impl Image {
         }
     }
 
-    /// Load an image from file path. Supports BMP and PNG
+    /// Load an image from file path. Supports BMP and PNG extensions.
     pub fn from_path<P: std::string::ToString + AsRef<Path>>(path: P) -> Result<Self, String> {
         let source = path.to_string();
 

--- a/crates/render/src/web/mod.rs
+++ b/crates/render/src/web/mod.rs
@@ -65,7 +65,8 @@ impl RenderContext2D {
 
     // Rectangles
 
-    /// Draws a filled rectangle whose starting point is at the coordinates {x, y} with the specified width and height and whose style is determined by the fillStyle attribute.
+    /// Draws a filled rectangle whose starting point is at the coordinates {x, y} with the
+    /// specified width and height and whose style is determined by the fillStyle attribute.
     pub fn fill_rect(&mut self, x: f64, y: f64, width: f64, height: f64) {
         self.fill_style(&self.config.fill_style);
         self.canvas_render_context_2_d
@@ -134,7 +135,8 @@ impl RenderContext2D {
         self.canvas_render_context_2_d.begin_path();
     }
 
-    /// Attempts to add a straight line from the current point to the start of the current sub-path. If the shape has already been closed or has only one point, this function does nothing.
+    /// Attempts to add a straight line from the current point to the start of the current sub-path.
+    /// If the shape has already been closed or has only one point, this function does nothing.
     pub fn close_path(&mut self) {
         self.canvas_render_context_2_d.close_path();
     }
@@ -167,7 +169,9 @@ impl RenderContext2D {
             .quadratic_curve_to(cpx, cpy, x, y);
     }
 
-    /// Adds a cubic Bézier curve to the current sub-path. It requires three points: the first two are control points and the third one is the end point. The starting point is the latest point in the current path, which can be changed using MoveTo{} before creating the Bézier curve.
+    /// Adds a cubic Bézier curve to the current sub-path.
+    /// It requires three points: the first two are control points and the third one is the end point.
+    /// The starting point is the latest point in the current path, which can be changed using MoveTo{} before creating the Bézier curve.
     pub fn bezier_curve_to(&mut self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
         self.canvas_render_context_2_d
             .bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y);
@@ -321,7 +325,7 @@ impl RenderContext2D {
 
     // Transformations
 
-    /// Sets the tranformation.
+    /// Sets the transformation.
     pub fn set_transform(
         &mut self,
         h_scaling: f64,
@@ -344,7 +348,8 @@ impl RenderContext2D {
         self.canvas_render_context_2_d.save();
     }
 
-    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack. If there is no saved state, this method does nothing.
+    /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack.
+    /// If there is no saved state, this method does nothing.
     pub fn restore(&mut self) {
         self.canvas_render_context_2_d.restore();
         if let Some(config) = &self.saved_config {

--- a/crates/shell/src/window.rs
+++ b/crates/shell/src/window.rs
@@ -2,10 +2,8 @@
 
 use crate::{event::*, utils::Point};
 
-/// The window adapter is used to work with the window shell.ButtonState
-///
-/// It handles updates from the shell and provides method to update and render
-/// its content.
+/// The window adapter is used to work with the window shell.
+/// It handles updates from the shell and provides method to update and render its content.
 pub trait WindowAdapter {
     // /// Renders the content.
     // fn render(&mut self, _canvas: &mut Canvas) {}

--- a/crates/tree/src/lib.rs
+++ b/crates/tree/src/lib.rs
@@ -35,7 +35,7 @@ pub enum NotFound {
     Child(Entity),
 }
 
-/// Base data structure to manage the entity entities of a window in a tree based structure.
+/// Base data structure to manage the entities of a window in a tree based structure.
 #[derive(Clone, Default, Debug)]
 pub struct Tree {
     pub root: Option<Entity>,

--- a/crates/utils/src/alignment.rs
+++ b/crates/utils/src/alignment.rs
@@ -14,8 +14,8 @@ impl Default for Alignment {
 }
 
 impl Alignment {
-    /// Calculates the position (x or y) of the widget depending on the available measure, the goal measure
-    /// margin and alignment.
+    /// Calculates the position (x or y) of the widget depending on the available measure,
+    /// the goal measure margin and alignment.
     pub fn align_position(
         self,
         available_measure: f64,
@@ -30,8 +30,8 @@ impl Alignment {
         }
     }
 
-    /// Calculates the measure (measure or height) of the widget depending on the available measure, the goal measure
-    /// margin and horizontal alignment.
+    /// Calculates the measure (measure or height) of the widget depending on the available measure,
+    /// the goal measure margin and horizontal alignment.
     pub fn align_measure(
         self,
         available_measure: f64,

--- a/crates/utils/src/color.rs
+++ b/crates/utils/src/color.rs
@@ -16,7 +16,7 @@ impl Color {
         }
     }
 
-    /// Set the alpha
+    /// Create a new color from RGB and alpha values
     pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Color {
             data: ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32),
@@ -99,7 +99,7 @@ impl From<String> for Color {
     }
 }
 
-/// Compare two colors (Do not take care of alpha)
+/// Compares two colors (the alpha value is ignored)
 impl PartialEq for Color {
     fn eq(&self, other: &Color) -> bool {
         self.r() == other.r() && self.g() == other.g() && self.b() == other.b()

--- a/crates/utils/src/rectangle.rs
+++ b/crates/utils/src/rectangle.rs
@@ -1,7 +1,7 @@
 /// Describes a new visual rectangle.
 #[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct Rectangle {
-    //// X position of the rectangle.
+    /// X position of the rectangle.
     pub x: f64,
 
     /// Y position of the rectangle.

--- a/crates/utils/src/string16.rs
+++ b/crates/utils/src/string16.rs
@@ -31,7 +31,7 @@ impl String16 {
         self.utf16.len()
     }
 
-    /// /// Returns a slice of [`u16`]s bytes that were attempted to convert to a `String`.
+    /// Returns a slice of [`u16`]s bytes that were attempted to convert to a `String`.
     pub fn as_bytes(&self) -> &[u16] {
         &self.utf16
     }
@@ -69,7 +69,7 @@ impl String16 {
         self.utf16.is_empty()
     }
 
-    // Returns `true` if this `String16` ends with the given string slice, and `false` otherwise.
+    /// Returns `true` if this `String16` ends with the given string slice, or `false` otherwise.
     pub fn ends_with(&self, pat: &str) -> bool {
         self.as_string().ends_with(pat)
     }

--- a/crates/widgets/src/canvas.rs
+++ b/crates/widgets/src/canvas.rs
@@ -1,11 +1,9 @@
 use crate::prelude::*;
-// CanvasState
-// updates the ThreeObject property
 
 widget!(
     /// Canvas is used to render 3D graphics.
     Canvas {
-        /// Sets or shares the three render pipeline.
+        /// Sets or shares the render pipeline.
         render_pipeline: RenderPipeline
     }
 );

--- a/crates/widgets/src/grid.rs
+++ b/crates/widgets/src/grid.rs
@@ -18,10 +18,10 @@ widget!(
         border_radius: f64
 
         attached_properties: {
-            /// Attach a colum position to a widget.
+            /// Attach a column position to a widget.
             column: usize,
 
-            /// Attach a colum span to a widget.
+            /// Attach a column span to a widget.
             column_span: usize,
 
             /// Attach a row position to a widget.

--- a/crates/widgets/src/list_view.rs
+++ b/crates/widgets/src/list_view.rs
@@ -91,7 +91,7 @@ impl State for ListViewState {
     }
 }
 
-/// The `ListViewItemState` handles the interaction an selection of a `ListViewItem`.
+/// The `ListViewItemState` handles the interaction and selection of a `ListViewItem`.
 #[derive(Default, AsAny)]
 pub struct ListViewItemState {
     request_selection_toggle: Cell<bool>,
@@ -271,7 +271,7 @@ widget!(
         /// Sets or shares the orientation property.
         orientation: Orientation,
 
-        /// Sets or shared the count.
+        /// Sets or shares the item count.
         count: usize,
 
         /// Sets or shares the selection mode property.
@@ -289,7 +289,7 @@ widget!(
 );
 
 impl ListView {
-    /// Define the template build function for the content of the LisetViewItems.
+    /// Define the template build function for the content of the ListViewItems.
     pub fn items_builder<F: Fn(&mut BuildContext, usize) -> Entity + 'static>(
         mut self,
         builder: F,

--- a/crates/widgets/src/popup.rs
+++ b/crates/widgets/src/popup.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-/// The `PopupStates` handles the open and close behavior the the `Popup`.
+/// The `PopupState` handles the open and close behavior of the `Popup` widget.
 #[derive(Default, AsAny)]
 pub struct PopupState {}
 

--- a/crates/widgets/src/slider.rs
+++ b/crates/widgets/src/slider.rs
@@ -158,10 +158,10 @@ widget!(
     ///
     /// **CSS element:** `Slider`
     Slider<SliderState>: MouseHandler, ChangedHandler {
-        /// Sets or shares the minimum of the range.
+        /// Sets or shares the minimum value of the range.
         minimum: f64,
 
-        /// Sets or shared the maximum of the range.
+        /// Sets or shares the maximum value of the range.
         maximum: f64,
 
         /// Sets or shares the current value of the range.

--- a/crates/widgets/src/text_block.rs
+++ b/crates/widgets/src/text_block.rs
@@ -14,7 +14,7 @@ widget!(
         /// Sets or shares the foreground property.
         foreground: Brush,
 
-        /// Sets or share the font size property.
+        /// Sets or shares the font size property.
         font_size: f64,
 
         /// Sets or shares the font property.

--- a/crates/widgets/src/text_box.rs
+++ b/crates/widgets/src/text_box.rs
@@ -333,7 +333,7 @@ widget!(
         /// Sets or shares the foreground property.
         foreground: Brush,
 
-        /// Sets or share the font size property.
+        /// Sets or shares the font size property.
         font_size: f64,
 
         /// Sets or shares the font property.

--- a/crates/widgets/src/toggle_button.rs
+++ b/crates/widgets/src/toggle_button.rs
@@ -29,7 +29,7 @@ widget!(
         /// Sets or shares the text property.
         text: String16,
 
-        /// Sets or share the font size property.
+        /// Sets or shares the font size property.
         font_size: f64,
 
         /// Sets or shares the font property.
@@ -41,7 +41,7 @@ widget!(
         /// Sets or shares the icon brush property.
         icon_brush: Brush,
 
-        /// Sets or share the icon font size property.
+        /// Sets or shares the icon font size property.
         icon_size: f64,
 
         /// Sets or shares the icon font property.

--- a/crates/widgets/src/window.rs
+++ b/crates/widgets/src/window.rs
@@ -113,7 +113,7 @@ impl State for WindowState {
 }
 
 widget!(
-    /// The `Window` widget provides access to the properties of a application window.
+    /// The `Window` widget provides access to the properties of an application window.
     /// It also contains global properties like keyboard modifier and focused widget.
     ///
     /// **CSS element:** `window`


### PR DESCRIPTION
Fixed typos in docs comments in all crates.
Broke some comments that wider than 120 chars into multiple lines.
Rewrote some docs.