### PR TITLE
Close `ComboBox` when an item is selected

### DIFF
--- a/crates/widgets/src/combo_box.rs
+++ b/crates/widgets/src/combo_box.rs
@@ -211,7 +211,7 @@ impl ComboBoxState {
             popup_bounds.height,
         );
 
-        if !combo_box_global_bounds.contains((x, y)) && !popup_global_bounds.contains((x, y)) {
+        if !combo_box_global_bounds.contains((x, y)) {
             ctx.widget().set("selected", false);
             ctx.get_widget(self.popup)
                 .set("visibility", Visibility::Collapsed);


### PR DESCRIPTION
I was annoyed that `ComboBox`es stay open when you click on an item. This pull request changes that.