### PR TITLE
Pgbar improvements

### DIFF
--- a/crates/widgets/src/progress_bar.rs
+++ b/crates/widgets/src/progress_bar.rs
@@ -10,14 +10,11 @@ struct BarState {
 }
 
 impl State for BarState {
-    fn init(&mut self, _: &mut Registry, ctx: &mut Context) {
+    fn init(&mut self, registry: &mut Registry, ctx: &mut Context) {
         self.indicator = ctx
             .entity_of_child(ID_INDICATOR)
             .expect("BarState.init(): Child could not be found!");
-
-        ctx.get_widget(self.indicator)
-            .get_mut::<Constraint>("constraint")
-            .set_width(0.1);
+        self.update(registry, ctx);
     }
 
     fn update(&mut self, _: &mut Registry, ctx: &mut Context) {

--- a/crates/widgets/src/progress_bar.rs
+++ b/crates/widgets/src/progress_bar.rs
@@ -47,7 +47,7 @@ widget!(
     /// (e.g. copying a file, downloading a video from the internet).
     /// A progress is visually represented as a horizontal bar which grows when the progress advances.
     /// The ProgressBar expects values between 0.0 and 1.0, whereas 0.0 means 0%, and 1.0 means 100%.
-    /// Any value outside of this range cosidered as 100%.
+    /// Any value outside of this range considered as 100%.
     ///
     /// This example creates a ProgressBar with default values:
     /// ```rust
@@ -96,11 +96,12 @@ impl Template for ProgressBar {
                     .element("progress_bar_indicator")
                     .background("#EFD035")
                     .height(24.0)
-                    .v_align("start")
+                    .v_align("center")
                     .border_radius(1.0)
                     .width(0.0)
                     .build(ctx),
             )
+            .width(100.0)
             .val(0.0)
     }
 


### PR DESCRIPTION
When the rendering was slow, you could see the progressbar is empty before the first update() is called. This is not a problem anymore, just in case calling update() from init since the code that would set the init value would be the same as update().
Indicator vertical-align set to center.This fixes the drawing position of the indicator when the progress bar is a child of a Stack.