### PR TITLE
Bugfix: example -> widgets

### DIFF
--- a/crates/api/src/widget/widget_container.rs
+++ b/crates/api/src/widget/widget_container.rs
@@ -62,7 +62,7 @@ impl<'a> WidgetContainer<'a> {
     ///
     /// # Panics
     ///
-    /// Panics if the widget does not contains the property.
+    /// Panics if the widget does not contain the property.
     pub fn get_mut<P>(&mut self, key: &str) -> &mut P
     where
         P: Clone + Component,

--- a/examples/widgets.rs
+++ b/examples/widgets.rs
@@ -41,12 +41,14 @@ impl State for MainViewState {
                         main_view(ctx.widget())
                             .list_mut()
                             .push(format!("Item {}", len + 1));
-                            ctx.child("items").set::<usize>("count", len + 1);
+                        ctx.child("items").clone_or_default::<usize>("Item");
                         items_widget(ctx.child("items")).set_count(len + 1);
                         button(ctx.child("remove-item-button")).set_enabled(true);
+                        button(ctx.child("remove-item-button")).set_visibility(Visibility::Visible);
 
                         if len == 4 {
                             button(ctx.child("add-item-button")).set_enabled(false);
+                            button(ctx.child("add-item-button")).set_visibility(Visibility::Collapsed);
                         }
                     }
                 }
@@ -56,9 +58,11 @@ impl State for MainViewState {
                         main_view(ctx.widget()).list_mut().remove(len - 1);
                         items_widget(ctx.child("items")).set_count(len - 1);
                         button(ctx.child("add-item-button")).set_enabled(true);
+                        button(ctx.child("add-item-button")).set_visibility(Visibility::Visible);
 
                         if len == 1 {
                             button(ctx.child("remove-item-button")).set_enabled(false);
+                            button(ctx.child("remove-item-button")).set_visibility(Visibility::Collapsed);
                         }
                     }
                 }
@@ -144,16 +148,16 @@ impl Template for MainView {
             ])
             .list_count(3)
             .selection_list(vec![
-                "Item 1".to_string(),
-                "Item 2".to_string(),
-                "Item 3".to_string(),
-                "Item 4".to_string(),
-                "Item 5".to_string(),
-                "Item 6".to_string(),
-                "Item 7".to_string(),
-                "Item 8".to_string(),
-                "Item 9".to_string(),
-                "Item 10".to_string(),
+                "Select Item 1".to_string(),
+                "Select Item 2".to_string(),
+                "Select Item 3".to_string(),
+                "Select Item 4".to_string(),
+                "Select Item 5".to_string(),
+                "Select Item 6".to_string(),
+                "Select Item 7".to_string(),
+                "Select Item 8".to_string(),
+                "Select Item 9".to_string(),
+                "Select Item 10".to_string(),
             ])
             .combo_box_list(vec![
                 "CB 1".to_string(),
@@ -369,6 +373,7 @@ impl Template for MainView {
                                     .attach(Grid::column_span(3))
                                     .attach(Grid::row(3))
                                     .margin((0., 0., 0., 8.))
+                                    // bc = build-context
                                     .items_builder(move |bc, index| {
                                         let text = bc.get_widget(id).get::<Vec<String>>("list")
                                             [index]


### PR DESCRIPTION
# Bug

when adding a new item to the ComboBox, the app will panic.

# Resolution

use method clone_or_default(), that takes care to get that right.

# Add-On

* A typo correction
* Showing an 'Add' button only make sense, if the item length is less then our intended max (here: we only allow 5 items)
* Showing a 'Remove' button only make sense, if the item length is bigger then 1 (an item exists in the list)

Updated the code to respect this constraints.

