### PR TITLE
Padding Layout does not resize fix

### DIFF
--- a/crates/api/src/layout/padding.rs
+++ b/crates/api/src/layout/padding.rs
@@ -14,6 +14,7 @@ use super::{component, component_try_mut, Layout};
 pub struct PaddingLayout {
     desired_size: RefCell<DirtySize>,
     old_alignment: Cell<(Alignment, Alignment)>,
+    old_parent_size: Cell<(f64,f64)>
 }
 
 impl PaddingLayout {
@@ -94,7 +95,7 @@ impl Layout for PaddingLayout {
                     .set_size(desired_size.0, desired_size.1);
             }
         }
-
+        self.desired_size.borrow_mut().set_dirty(true);
         *self.desired_size.borrow()
     }
 
@@ -112,9 +113,11 @@ impl Layout for PaddingLayout {
             return (0.0, 0.0);
         }
 
-        if !self.desired_size.borrow().dirty() {
+        if !self.desired_size.borrow().dirty() && parent_size == self.old_parent_size.get()
+        {
             return self.desired_size.borrow().size();
         }
+        
 
         let horizontal_alignment: Alignment = component(ecm, entity, "h_align");
         let vertical_alignment: Alignment = component(ecm, entity, "v_align");
@@ -194,7 +197,7 @@ impl Layout for PaddingLayout {
                 );
             }
         }
-
+        self.old_parent_size.set(parent_size);
         self.desired_size.borrow_mut().set_dirty(false);
         size
     }


### PR DESCRIPTION
Hi,
i have found a bug that does not allow to the PaddinLayout to resize on window size change. 
From what i have understood, the layout calculation is based on 2 functions: measure and arrange (both provided by Layout trait).
First measure is called (it is supposed to calculate the size, keeping into consideration all it's children). When completed, it return a DirtySize object. If this object is "dirty", the layout function is called (it is supposed to calculate the position of the object and all it's children), otherwise not.
The problem is that when the window resize, only the layout function is aware of this change (because the new size is passed as parameter) and, if the measure function return a "clean" DirtySize, the layout function is never called, making impossible to resize the widget.
This is exactly what happen to the PaddingLayout. Other layouts works (more or less) because they force the dirty state on the DirtySize object returned by measure.
The applied solution also force the dirty state on the DirtySize and keep trace of the old parent size. During the layout call, among other checks, the passed new parent size is compared with the old parent size. If they are different, redraw is done as normal, otherwise return the current layout size.
Hope it helps,
Thanks for the attention