### PR TITLE
Adding Serialize Deserialize derive for String16

### DIFF
--- a/crates/utils/src/string16.rs
+++ b/crates/utils/src/string16.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use serde::{Serialize, Deserialize};
 
 /// A UTF-16 encoded, growable string.
 ///
@@ -6,7 +7,7 @@ use std::fmt;
 ///
 /// let mut string16 = String16::from("Übung");
 /// string16.push('ä');
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct String16 {
     utf16: Vec<u16>,
 }


### PR DESCRIPTION
Hi,
i have noticed that the toolkit is able to store and load setting configuration using ron format and serde. For an application that i'm made i need to save String16 type, but the type does not implement the needed Serialize Deserialize traits. I made this change locally, but I think that this could be generally useful and should not generate any problems, so i pushed this change.
Thanks for the attention
 