### PR TITLE
Implementing IntoPropertySource<P> for PropertySource<P>

### DIFF
--- a/crates/api/src/properties/mod.rs
+++ b/crates/api/src/properties/mod.rs
@@ -49,6 +49,11 @@ impl<P: Component + Debug> From<Entity> for PropertySource<P> {
     }
 }
 
+impl<P: Component + Debug> IntoPropertySource<P> for PropertySource<P>
+{
+    fn into_source(self) -> PropertySource<P> {self}
+}
+
 /// Used to convert components / properties into a PropertySource object.
 pub trait IntoPropertySource<P: Component + Debug> {
     fn into_source(self) -> PropertySource<P>;


### PR DESCRIPTION
Hi,
this implementation allow to pass object of type PropertySource<P> during the template construction of a widget, like
```
TextBlock::new()
.text(PropertySource::KeySource("other_field_name",other_entity_id))
.build(ctx)
```
Normally, during the template construction, during a field construction, is possible to pass an Entity object and a field with the same name on that Entity will be key-sourced.
Allowing to pass PropertySource object is possible to set as key-source a field with a different name (but the same type), allowing for a faster widget customization.
Hope this help, thanks for the attention