### PR TITLE
ToggleButton animation

### DIFF
--- a/crates/theme/assets/dark/dark.ron
+++ b/crates/theme/assets/dark/dark.ron
@@ -85,29 +85,6 @@ Theme (
                 "spacing": 0,
             },
         ),
-	"toggle-button": (
-            base: "base",
-            properties: {
-                "height": 36,
-                "foreground": "$LINK_WATER",
-                "icon_brush": "$LINK_WATER",
-                "background": "$LYNCH",
-                "border_radius": 4,
-            },
-            states: {
-                "pressed": {
-                    "background": "$BLUE_BAYOUX",
-                },
-                "selected": {
-                    "background": "$BLUE_BAYOUX",
-                },
-                "disabled": {
-                    "background": "$ROLLING_STONE",
-                    "foreground": "$BRIGHT_GRAY",
-                    "icon_brush": "$BRIGHT_GRAY",
-                },
-            },
-        ),
         "check_box": (
             base: "base",
             properties: {

--- a/crates/theme/assets/dark/dark.ron
+++ b/crates/theme/assets/dark/dark.ron
@@ -85,6 +85,29 @@ Theme (
                 "spacing": 0,
             },
         ),
+	"toggle-button": (
+            base: "base",
+            properties: {
+                "height": 36,
+                "foreground": "$LINK_WATER",
+                "icon_brush": "$LINK_WATER",
+                "background": "$LYNCH",
+                "border_radius": 4,
+            },
+            states: {
+                "pressed": {
+                    "background": "$BLUE_BAYOUX",
+                },
+                "selected": {
+                    "background": "$BLUE_BAYOUX",
+                },
+                "disabled": {
+                    "background": "$ROLLING_STONE",
+                    "foreground": "$BRIGHT_GRAY",
+                    "icon_brush": "$BRIGHT_GRAY",
+                },
+            },
+        ),
         "check_box": (
             base: "base",
             properties: {

--- a/crates/theme/assets/light/light.ron
+++ b/crates/theme/assets/light/light.ron
@@ -83,29 +83,6 @@ Theme (
                 "spacing": 0,
             },
         ),
-	"toggle-button": (
-            base: "base",
-            properties: {
-                "height": 36,
-                "foreground": "$BRIGHT_GRAY",
-                "icon_brush": "$BRIGHT_GRAY",
-                "background": "$ALTO",
-                "border_radius": 4,
-            },
-            states: {
-                "pressed": {
-                    "background": "$SILVER_CHALICE",
-                },
-                "selected": {
-                    "background": "$SILVER_CHALICE",
-                },
-                "disabled": {
-                    "background": "$ROLLING_STONE",
-                    "foreground": "$BRIGHT_GRAY",
-                    "icon_brush": "$BRIGHT_GRAY",
-                },
-            },
-        ),
         "check_box": (
             base: "base",
             properties: {

--- a/crates/theme/assets/light/light.ron
+++ b/crates/theme/assets/light/light.ron
@@ -83,6 +83,29 @@ Theme (
                 "spacing": 0,
             },
         ),
+	"toggle-button": (
+            base: "base",
+            properties: {
+                "height": 36,
+                "foreground": "$BRIGHT_GRAY",
+                "icon_brush": "$BRIGHT_GRAY",
+                "background": "$ALTO",
+                "border_radius": 4,
+            },
+            states: {
+                "pressed": {
+                    "background": "$SILVER_CHALICE",
+                },
+                "selected": {
+                    "background": "$SILVER_CHALICE",
+                },
+                "disabled": {
+                    "background": "$ROLLING_STONE",
+                    "foreground": "$BRIGHT_GRAY",
+                    "icon_brush": "$BRIGHT_GRAY",
+                },
+            },
+        ),
         "check_box": (
             base: "base",
             properties: {

--- a/crates/widgets/src/toggle_button.rs
+++ b/crates/widgets/src/toggle_button.rs
@@ -61,7 +61,7 @@ widget!(
 impl Template for ToggleButton {
     fn template(self, id: Entity, ctx: &mut BuildContext) -> Self {
         self.name("ToggleButton")
-            .style("toggle-button")
+            .style("button")
             .selected(false)
             .height(36.0)
             .min_width(64.0)


### PR DESCRIPTION
Hi,
i have noticed that the ToggleButton widget do not change background color on toggle. After verify that the button effectively work and that it is only a visual bug, i found that on theme files the "toggle-button" theme (used on ToggleButton widget) is missing on both light and dark theme. I have simply copied the button theme and renamed it to "toggle-button" since, as i remember, the ToggleButton widget had the same theme as the Button widget (this should be a regression because i remember that it worked a week ago).
Thanks for the attention,
Have a nice day