### PR TITLE
TabWidget close button visibility cannot be toggled during template construction

### DIFF
--- a/crates/widgets/src/tab_widget.rs
+++ b/crates/widgets/src/tab_widget.rs
@@ -438,6 +438,7 @@ impl State for TabWidgetState {
     fn init(&mut self, _: &mut Registry, ctx: &mut Context) {
         self.header_container = ctx.child(HEADER_CONTAINER).entity();
         self.body_container = ctx.child(BODY_CONTAINER).entity();
+        self.close_button_visibility = true;
     }
     fn update(&mut self, _: &mut Registry, ctx: &mut Context) {
         let actions: Vec<TabWidgetAction> = self.actions.drain(..).collect();
@@ -520,7 +521,6 @@ impl Template for TabWidget {
     fn template(self, id: Entity, ctx: &mut BuildContext) -> Self {
         self.name("TabWidget")
             .style("tab_widget")
-            .close_button(true)
             .child(
                 Grid::new()
                     .rows(Rows::new().add(32).add("*"))


### PR DESCRIPTION
Hi,
i have noticed a little problem on the TabWidget: if the close button visibility is setted from the outside of the widget, the change is ignored and setted true anyway. Using an example like:
```
TabWidget::new()
.close_button(false)
.tab("Tab header 1",TextBlock::new().text("Tab content 1").build(ctx))
.tab("Tab header 2",TextBlock::new().text("Tab content 2").build(ctx))
.tab("Tab header 3",TextBlock::new().text("Tab content 3").build(ctx))
.build(ctx);
```
can be noticed that the close button will appear anyway.
The problem is inside the TabWidget template function:
```
impl Template for TabWidget {
    fn template(self, id: Entity, ctx: &mut BuildContext) -> Self {
        self.name("TabWidget")
            .style("tab_widget")

            .close_button(true)           //HERE

            .child(
                Grid::new()
                    .rows(Rows::new().add(32).add("*"))
                    .child(
                        Stack::new()
                            .id(HEADER_CONTAINER)
                            .orientation("horizontal")
                            .spacing(id)
                            .build(ctx),
                    )
                    .child(
                        Container::new()
                            .id(BODY_CONTAINER)
                            .background(id)
                            .border_brush(id)
                            .border_width(id)
                            .border_radius(id)
                            .attach(Grid::row(1))
                            .build(ctx),
                    )
                    .build(ctx),
            )
    }
}
```
Generally when a property is setted, it cannot be overwritten by successive calls during the template building.
The `.close_button(true)` look like a property set, but it is not, it store a command on a Vec of actions that will be executed using FIFO ordering. So, since the template function is called at the end, it will overwrite any other choose the user make before (like the example above).
The solution is very simple: instead of setting the default button_close "property" inside the template, set it during the init function of the state. Since the init function is called before the template function, it will set the default value and then it could be freely overwritten by the user.
Sorry for this problem, i wrote the function to look like a property set, but it fooled me too :smile: 

Thanks for the attention,
Have a good day

PS: the new style look amazing, it is a very good work!