### PR TITLE
Multi-level clip

### DIFF
--- a/crates/render/src/raqote/mod.rs
+++ b/crates/render/src/raqote/mod.rs
@@ -109,14 +109,14 @@ impl RenderContext2D {
             let width = self.draw_target.width() as f64;
 
             if let Some(rect) = self.path_rect.get_clip() {
-                    font.render_text_clipped(
-                        text,
-                        self.draw_target.get_data_mut(),
-                        width,
-                        (self.config.font_config.font_size, color, self.config.alpha),
-                        (x, y),
-                        rect,
-                    );
+                font.render_text_clipped(
+                    text,
+                    self.draw_target.get_data_mut(),
+                    width,
+                    (self.config.font_config.font_size, color, self.config.alpha),
+                    (x, y),
+                    rect,
+                );
             } else {
                 font.render_text(
                     text,

--- a/crates/render/src/raqote/mod.rs
+++ b/crates/render/src/raqote/mod.rs
@@ -9,7 +9,7 @@ pub use self::image::Image;
 mod font;
 mod image;
 
-type StatesOnStack = [(RenderConfig, PathRect); 2];
+type StatesOnStack = [(RenderConfig, PathRect, usize); 2];
 
 /// The RenderContext2D trait, provides the rendering ctx. It is used for drawing shapes, text, images, and other objects.
 pub struct RenderContext2D {
@@ -19,6 +19,7 @@ pub struct RenderContext2D {
     saved_states: SmallVec<StatesOnStack>,
     fonts: HashMap<String, Font>,
     path_rect: PathRect,
+    clips_count: usize,
 
     background: Color,
 }
@@ -36,6 +37,7 @@ impl RenderContext2D {
             saved_states: SmallVec::<StatesOnStack>::new(),
             fonts: HashMap::new(),
             path_rect: PathRect::new(None),
+            clips_count: 0,
             background: Color::default(),
         }
     }
@@ -106,8 +108,7 @@ impl RenderContext2D {
         if let Some(font) = self.fonts.get(&self.config.font_config.family) {
             let width = self.draw_target.width() as f64;
 
-            if self.path_rect.get_clip() {
-                if let Some(rect) = self.path_rect.get_rect() {
+            if let Some(rect) = self.path_rect.get_clip() {
                     font.render_text_clipped(
                         text,
                         self.draw_target.get_data_mut(),
@@ -116,15 +117,6 @@ impl RenderContext2D {
                         (x, y),
                         rect,
                     );
-                } else {
-                    font.render_text(
-                        text,
-                        self.draw_target.get_data_mut(),
-                        width,
-                        (self.config.font_config.font_size, color, self.config.alpha),
-                        (x, y),
-                    );
-                }
             } else {
                 font.render_text(
                     text,
@@ -353,7 +345,8 @@ impl RenderContext2D {
     /// Creates a clipping path from the current sub-paths. Everything drawn after clip() is called appears inside the clipping path only.
     pub fn clip(&mut self) {
         self.draw_target.push_clip(&self.path);
-        self.path_rect.set_clip(true);
+        self.path_rect.record_clip();
+        self.clips_count += 1;
     }
 
     // Line styles
@@ -418,16 +411,19 @@ impl RenderContext2D {
     /// Saves the entire state of the canvas by pushing the current state onto a stack.
     pub fn save(&mut self) {
         self.saved_states
-            .push((self.config.clone(), self.path_rect));
+            .push((self.config.clone(), self.path_rect, self.clips_count));
     }
 
     /// Restores the most recently saved canvas state by popping the top entry in the drawing state stack.
     /// If there is no saved state, this method does nothing.
     pub fn restore(&mut self) {
-        self.draw_target.pop_clip();
-        if let Some((config, path_rect)) = self.saved_states.pop() {
+        if let Some((config, path_rect, former_clips_count)) = self.saved_states.pop() {
             self.config = config;
             self.path_rect = path_rect;
+            for _ in former_clips_count..self.clips_count {
+                self.draw_target.pop_clip();
+            }
+            self.clips_count = former_clips_count;
         }
     }
 

--- a/crates/render/src/web/mod.rs
+++ b/crates/render/src/web/mod.rs
@@ -309,7 +309,7 @@ impl RenderContext2D {
     /// Creates a clipping path from the current sub-paths. Everything drawn after clip() is called appears inside the clipping path only.
     pub fn clip(&mut self) {
         self.canvas_render_context_2_d.clip(FillRule::EvenOdd);
-        self.path_rect.set_clip(true);
+        self.path_rect.record_clip();
     }
 
     // Line styles

--- a/crates/utils/src/rectangle.rs
+++ b/crates/utils/src/rectangle.rs
@@ -151,20 +151,20 @@ impl Rectangle {
     }
 
     /// Box itself inside another rectangle
-    pub fn box_into(&mut self, _box: Rectangle) {
-        if self.x() < _box.x() {
-            self.set_width(self.width() - (_box.x() - self.x()));
-            self.set_x(_box.x());
+    pub fn box_into(&mut self, container: Rectangle) {
+        if self.x() < container.x() {
+            self.set_width(self.width() - (container.x() - self.x()));
+            self.set_x(container.x());
         }
-        if self.y() < _box.y() {
-            self.set_height(self.height() - (_box.y() - self.y()));
-            self.set_y(_box.y());
+        if self.y() < container.y() {
+            self.set_height(self.height() - (container.y() - self.y()));
+            self.set_y(container.y());
         }
-        if self.x() + self.width() > _box.x() + _box.width() {
-            self.set_width(_box.width() - _box.x() + self.x());
+        if self.x() + self.width() > container.x() + container.width() {
+            self.set_width(container.width() - container.x() + self.x());
         }
-        if self.y() + self.height() > _box.y() + _box.height() {
-            self.set_height(_box.height() - _box.y() + self.y());
+        if self.y() + self.height() > container.y() + container.height() {
+            self.set_height(container.height() - container.y() + self.y());
         }
     }
 }

--- a/crates/utils/src/rectangle.rs
+++ b/crates/utils/src/rectangle.rs
@@ -149,6 +149,24 @@ impl Rectangle {
             self.set_height(point.y() - self.y());
         }
     }
+
+    /// Box itself inside another rectangle
+    pub fn box_into(&mut self, _box: Rectangle) {
+        if self.x() < _box.x() {
+            self.set_width(self.width() - (_box.x() - self.x()));
+            self.set_x(_box.x());
+        }
+        if self.y() < _box.y() {
+            self.set_height(self.height() - (_box.y() - self.y()));
+            self.set_y(_box.y());
+        }
+        if self.x() + self.width() > _box.x() + _box.width() {
+            self.set_width(_box.width() - _box.x() + self.x());
+        }
+        if self.y() + self.height() > _box.y() + _box.height() {
+            self.set_height(_box.height() - _box.y() + self.y());
+        }
+    }
 }
 
 // --- Conversions ---


### PR DESCRIPTION
# Context:
This enables the possibility of doing multiple calls to `clip` in raqote and restore its previous state before, in that scenery OrbTk should fail to track the path dimensions and `restore` would fail to reverse the clip operation.