### PR TITLE
Is it a typo?

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ If you want to help improve OrbTk you submit your feedback in the issue tracker,
 * For widget development check ProgressBar or Slider as example
 * Add changes to changelog
 * Expand examples or create a new one if needed
-* `cargo fmt` add the end
+* `cargo fmt` at the end
 * Create PR
 
 ## License


### PR DESCRIPTION
# Context:
Is it a typo?
`cargo fmt` add the end -> `cargo fmt` at the end

Reference to a related issue in the repository.
@FloVanGH 

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
