### PR TITLE
use custom property names in theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replace String16 with std::string::String
 * Raise on_changed callback also on shared widgets
 * Localization
+* Custom theme names for types Brush, String, Thickness, f32, f64
 
 ### 0.3.1-alpha3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "dces"
 version = "0.3.1"
-source = "git+https://gitlab.redox-os.org/redox-os/dces-rust.git?branch=develop#08008d16c7b8254c8c8f0468fce21933fabe612f"
+source = "git+https://gitlab.redox-os.org/redox-os/dces-rust.git?branch=develop#df014f1e55860fd9146a03e64cfd648a1108f637"
 
 [[package]]
 name = "deflate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "dces"
 version = "0.3.1"
-source = "git+https://gitlab.redox-os.org/redox-os/dces-rust.git?branch=develop#67a4ed510b6301eb484e1630719d7d5570f9b905"
+source = "git+https://gitlab.redox-os.org/redox-os/dces-rust.git?branch=develop#08008d16c7b8254c8c8f0468fce21933fabe612f"
 
 [[package]]
 name = "deflate"
@@ -411,7 +411,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
 ]
@@ -422,7 +422,7 @@ version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
 ]
@@ -1237,7 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
 ]
@@ -1337,7 +1337,7 @@ name = "orbtk_proc_macros"
 version = "0.3.1-alpha4"
 dependencies = [
  "case",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
 ]
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -1753,7 +1753,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
 ]
 
 [[package]]
@@ -2127,7 +2127,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
 ]
@@ -2285,7 +2285,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2299,7 +2299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "serde",
  "serde_derive",
@@ -2326,7 +2326,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2499,7 +2499,7 @@ dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-shared",
@@ -2521,7 +2521,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn",
  "wasm-bindgen-backend",
@@ -2640,7 +2640,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030f56009d932bd9400bb472764fea8109be1b0fc482d9cd75496c943ac30328"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "xml-rs",
 ]

--- a/crates/api/src/widget_base/widget_container.rs
+++ b/crates/api/src/widget_base/widget_container.rs
@@ -117,6 +117,14 @@ impl<'a> WidgetContainer<'a> {
         }
     }
 
+    /// Check if the given type is the type of the property. If the property is not part of the widget `None` will be returned.
+    pub fn is<P: 'static>(&self, key: &str) -> Option<bool> {
+        self.ecm
+            .component_store()
+            .is::<P>(key, self.current_node)
+            .ok()
+    }
+
     /// Gets the property.
     ///
     /// # Panics
@@ -472,27 +480,44 @@ impl<'a> WidgetContainer<'a> {
         if let Some(props) = self.theme.properties(&selector) {
             for (key, value) in props {
                 match key.as_str() {
-                    "foreground" | "background" | "icon_brush" | "border_brush" => {
-                        self.update_value::<Brush, Value>(key, Value(value.clone()));
-                    }
-                    "font_size" | "icon_size" | "spacing" | "border_radius" => {
-                        self.update_value::<f64, Value>(key, Value(value.clone()));
-                    }
-                    "padding" | "border_width" => {
-                        self.update_value::<Thickness, Value>(key, Value(value.clone()));
-                    }
+                    // special mapping
                     "padding_left" | "padding_top" | "padding_right" | "padding_bottom" => {
                         self.update_padding(key, Value(value.clone()));
                     }
-                    "font" | "icon_font" => {
-                        self.update_value::<String, Value>(key, Value(value.clone()));
-                    }
-                    "opacity" => {
-                        self.update_value::<f32, Value>(key, Value(value.clone()));
-                    }
                     "width" | "height" | "min_width" | "min_height" | "max_width"
                     | "max_height" => self.update_constraint(key, Value(value.clone())),
-                    _ => {}
+                    _ => {
+                        // common mapping
+                        if let Some(is_type) = self.is::<Brush>(key) {
+                            if is_type {
+                                self.update_value::<Brush, Value>(key, Value(value.clone()));
+                            }
+                        }
+
+                        if let Some(is_type) = self.is::<f32>(key) {
+                            if is_type {
+                                self.update_value::<f32, Value>(key, Value(value.clone()));
+                            }
+                        }
+
+                        if let Some(is_type) = self.is::<f64>(key) {
+                            if is_type {
+                                self.update_value::<f64, Value>(key, Value(value.clone()));
+                            }
+                        }
+
+                        if let Some(is_type) = self.is::<Thickness>(key) {
+                            if is_type {
+                                self.update_value::<Thickness, Value>(key, Value(value.clone()));
+                            }
+                        }
+
+                        if let Some(is_type) = self.is::<String>(key) {
+                            if is_type {
+                                self.update_value::<String, Value>(key, Value(value.clone()));
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Context:

* use custom property names in ron theme files for `Brush`, `String`, `f32`, `f64` and `Thickness`

## Contribution checklist:
- [x] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [x] Add unit tests if possible
- [x] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter
