### PR TITLE
Change tense of `lost_focus_on_activation` to better convey meaning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add focus_state property to Window
 * Add theme property to Window
 * MasterDetail responsive navigation widget
+* Rename `lost_focus_on_activation` to `lose_focus_on_activation`
 
 ### 0.3.1-alpha3
 

--- a/crates/widgets/src/behaviors/text_behavior.rs
+++ b/crates/widgets/src/behaviors/text_behavior.rs
@@ -805,7 +805,7 @@ widget!(
         /// Sets or shares the font size property.
         font_size: f64,
 
-        /// Sets or shares ta value that describes if the widget should lost focus on activation (when Enter pressed).
+        /// Sets or shares ta value that describes if the widget should lose focus on activation (when Enter pressed).
         lose_focus_on_activation: bool,
 
         /// Sets or shares the request_focus property. Used to request focus from outside.Set to `true` to request focus.

--- a/crates/widgets/src/behaviors/text_behavior.rs
+++ b/crates/widgets/src/behaviors/text_behavior.rs
@@ -302,7 +302,7 @@ impl TextBehaviorState {
     // -- Selection --
 
     fn activate(&self, ctx: &mut Context) {
-        if *ctx.widget().get::<bool>("lost_focus_on_activation") {
+        if *ctx.widget().get::<bool>("lose_focus_on_activation") {
             ctx.push_event_by_window(FocusEvent::RemoveFocus(self.target));
         }
 
@@ -730,7 +730,7 @@ widget!(
     ///     * focused
     ///     * font
     ///     * font_size
-    ///     * lost_focus_on_activation
+    ///     * lose_focus_on_activation
     ///     * request_focus
     ///     * text
     ///     * selection
@@ -745,7 +745,7 @@ widget!(
     ///     focused: bool,
     ///     font: String,
     ///     font_size: f64,
-    ///     lost_focus_on_activation: bool,
+    ///     lose_focus_on_activation: bool,
     ///     request_focus: bool,
     ///     selection: TextSelection
     /// });
@@ -772,7 +772,7 @@ widget!(
     ///            .focused(id)
     ///            .font(id)
     ///            .font_size(id)
-    ///            .lost_focus_on_activation(id)
+    ///            .lose_focus_on_activation(id)
     ///            .target(id.0)
     ///            .request_focus(id)
     ///            .text(id)
@@ -806,7 +806,7 @@ widget!(
         font_size: f64,
 
         /// Sets or shares ta value that describes if the widget should lost focus on activation (when Enter pressed).
-        lost_focus_on_activation: bool,
+        lose_focus_on_activation: bool,
 
         /// Sets or shares the request_focus property. Used to request focus from outside.Set to `true` to request focus.
         request_focus: bool,
@@ -830,7 +830,7 @@ impl Template for TextBehavior {
             .text("")
             .selection(TextSelection::default())
             .focused(false)
-            .lost_focus_on_activation(true)
+            .lose_focus_on_activation(true)
             .select_all_on_focus(false)
             .on_key_down(move |states, event| -> bool {
                 states

--- a/crates/widgets/src/numeric_box.rs
+++ b/crates/widgets/src/numeric_box.rs
@@ -118,7 +118,7 @@ impl State for NumericBoxState {
                         self.change_val(self.current_value - self.step, ctx);
                     }
                     Key::Enter => {
-                        if *ctx.widget().get::<bool>("lost_focus_on_activation") {
+                        if *ctx.widget().get::<bool>("lose_focus_on_activation") {
                             ctx.push_event_by_window(FocusEvent::RemoveFocus(ctx.entity));
                         }
 
@@ -184,7 +184,7 @@ widget!(
         foreground: Brush,
 
         /// Sets or shares the value that describes if the NumericBox should lost focus on activation (when enter pressed).
-        lost_focus_on_activation: bool,
+        lose_focus_on_activation: bool,
 
         /// Sets or shares the minimum allowed value property
         min: f64,
@@ -211,7 +211,7 @@ impl Template for NumericBox {
             .border_radius(3.0)
             .focused(false)
             .height(32.0)
-            .lost_focus_on_activation(true)
+            .lose_focus_on_activation(true)
             .min(0.0)
             .max(200.0)
             .step(1.0)
@@ -252,7 +252,7 @@ impl Template for NumericBox {
                             .enabled(false)
                             .max_width(96.)
                             .text("0")
-                            .lost_focus_on_activation(id)
+                            .lose_focus_on_activation(id)
                             .build(ctx),
                     )
                     .child(

--- a/crates/widgets/src/numeric_box.rs
+++ b/crates/widgets/src/numeric_box.rs
@@ -183,7 +183,7 @@ widget!(
         /// Sets or shares the foreground color property
         foreground: Brush,
 
-        /// Sets or shares the value that describes if the NumericBox should lost focus on activation (when enter pressed).
+        /// Sets or shares the value that describes if the NumericBox should lose focus on activation (when enter pressed).
         lose_focus_on_activation: bool,
 
         /// Sets or shares the minimum allowed value property

--- a/crates/widgets/src/password_box.rs
+++ b/crates/widgets/src/password_box.rs
@@ -111,7 +111,7 @@ widget!(
         focused: bool,
 
         /// Sets or shares ta value that describes if the PasswordBox should lost focus on activation (when Enter pressed).
-        lost_focus_on_activation: bool,
+        lose_focus_on_activation: bool,
 
         /// Used to request focus from outside. Set to `true` tor request focus.
         request_focus: bool,
@@ -143,7 +143,7 @@ impl Template for PasswordBox {
             .focused(id)
             .font(id)
             .font_size(id)
-            .lost_focus_on_activation(id)
+            .lose_focus_on_activation(id)
             .select_all_on_focus(id)
             .request_focus(id)
             .text(id)
@@ -168,7 +168,7 @@ impl Template for PasswordBox {
             .min_width(128.0)
             .height(32.0)
             .focused(false)
-            .lost_focus_on_activation(true)
+            .lose_focus_on_activation(true)
             .select_all_on_focus(true)
             .child(text_behavior)
             .child(

--- a/crates/widgets/src/password_box.rs
+++ b/crates/widgets/src/password_box.rs
@@ -110,7 +110,7 @@ widget!(
         /// Sets or shares the focused property.
         focused: bool,
 
-        /// Sets or shares ta value that describes if the PasswordBox should lost focus on activation (when Enter pressed).
+        /// Sets or shares ta value that describes if the PasswordBox should lose focus on activation (when Enter pressed).
         lose_focus_on_activation: bool,
 
         /// Used to request focus from outside. Set to `true` tor request focus.

--- a/crates/widgets/src/text_box.rs
+++ b/crates/widgets/src/text_box.rs
@@ -50,7 +50,7 @@ widget!(
         focused: bool,
 
         /// Sets or shares ta value that describes if the TextBox should lost focus on activation (enter).
-        lost_focus_on_activation: bool,
+        lose_focus_on_activation: bool,
 
         /// Used to request focus from outside. Set to `true` tor request focus.
         request_focus: bool,
@@ -82,7 +82,7 @@ impl Template for TextBox {
             .focused(id)
             .font(id)
             .font_size(id)
-            .lost_focus_on_activation(id)
+            .lose_focus_on_activation(id)
             .select_all_on_focus(id)
             .request_focus(id)
             .text(id)
@@ -104,7 +104,7 @@ impl Template for TextBox {
             .min_width(128.0)
             .height(32.0)
             .focused(false)
-            .lost_focus_on_activation(true)
+            .lose_focus_on_activation(true)
             .select_all_on_focus(true)
             .child(text_behavior)
             .child(

--- a/crates/widgets/src/text_box.rs
+++ b/crates/widgets/src/text_box.rs
@@ -49,7 +49,7 @@ widget!(
         /// Sets or shares the focused property.
         focused: bool,
 
-        /// Sets or shares ta value that describes if the TextBox should lost focus on activation (enter).
+        /// Sets or shares ta value that describes if the TextBox should lose focus on activation (enter).
         lose_focus_on_activation: bool,
 
         /// Used to request focus from outside. Set to `true` tor request focus.


### PR DESCRIPTION
# Context:
I think changing `lost_focus_on_activation` to `lose_focus_on_activation` better conveys the intended meaning since `lost` implies, at least in my understanding, that something already happend. `lose` indicates it will happen on activation. Maybe a native speaker could weigh in on this.

## Contribution checklist:
- [x] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter
