### PR TITLE
change event_state_system to include mouse up handling

### DIFF
--- a/crates/api/src/systems/event_state_system.rs
+++ b/crates/api/src/systems/event_state_system.rs
@@ -251,6 +251,39 @@ impl EventStateSystem {
                     }
                     unknown_event = false;
                 }
+                // mouse up handling
+                if let Ok(event) = event.downcast_ref::<MouseUpEvent>() {
+                    if check_mouse_condition(
+                        event.position,
+                        &WidgetContainer::new(
+                            current_node,
+                            ecm,
+                            &theme,
+                            Some(&self.context_provider.event_queue),
+                        ),
+                    ) {
+                        let mut add = true;
+                        if let Some(op) = clipped_parent.get(0) {
+                            // todo: improve check path if exists
+                            if !check_mouse_condition(
+                                event.position,
+                                &WidgetContainer::new(
+                                    *op,
+                                    ecm,
+                                    &theme,
+                                    Some(&self.context_provider.event_queue),
+                                ),
+                            ) && has_handler
+                            {
+                                add = false;
+                            }
+                        }
+                        if add {
+                            matching_nodes.push(current_node);
+                        }
+                    }
+                    unknown_event = false;
+                }
                 // mouse move handling
                 if let Ok(event) = event.downcast_ref::<MouseMoveEvent>() {
                     if check_mouse_condition(


### PR DESCRIPTION
# Context:
Currently, `MouseUpEvent` seems not correctly handled. When working on canvas interactivity (#353), I noticed `MouseUpEvent` firing when clicking outsite the canvas. This PR changes that to the expected behavior of only firing if clicking on the canvas. I'm not sure if this has any unexpected side effects, I couldn't find/notice any.


## Contribution checklist:
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter
