### PR TITLE
Fix multiline text and implement IntoPropertySource for PathBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,8 +580,10 @@ dependencies = [
  "ron",
  "serde",
  "serde_derive",
+ "smallvec",
  "stdweb",
  "threadpool",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1247,6 +1249,12 @@ name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
+unicode-width = "0.1"
+smallvec = { version = "1", default-features = false }
 ron = "0.6"
 memchr = "2"
 dirs = "3.0"

--- a/crates/api/src/layout/fixed_size.rs
+++ b/crates/api/src/layout/fixed_size.rs
@@ -1,10 +1,13 @@
 use std::{
     cell::{Cell, RefCell},
     collections::BTreeMap,
+    iter
 };
 
 use dces::prelude::*;
 use memchr::memchr_iter;
+use unicode_width::UnicodeWidthStr;
+use smallvec::SmallVec;
 
 use crate::{
     proc_macros::IntoLayout,
@@ -58,7 +61,7 @@ impl Layout for FixedSizeLayout {
 
         let size = widget
             .try_get::<Image>("image")
-            .map(|image| (image.width(), image.height()))
+            .map(|image| (Size::new(image.width(), image.height())))
             .or_else(|| {
                 text(&widget).and_then(|text| {
                     let font = widget.get::<String>("font");
@@ -69,30 +72,10 @@ impl Layout for FixedSizeLayout {
                             .try_get::<String>("water_mark")
                             .filter(|water_mark| !water_mark.is_empty())
                             .map(|water_mark| {
-                                let text_metrics = render_context_2_d.measure(
-                                    &water_mark,
-                                    *font_size,
-                                    font.as_str(),
-                                );
-                                (
-                                    text_metrics.width,
-                                    text_metrics.height
-                                        * ((memchr_iter(b'\n', water_mark.as_bytes()).count()
-                                            as f64)
-                                            * 1.15
-                                            + 1.0),
-                                )
+                                measure_text(render_context_2_d, &water_mark, font.as_str(), *font_size)
                             })
                     } else {
-                        let text_metrics =
-                            render_context_2_d.measure(&text, *font_size, font.as_str());
-
-                        Some((
-                            text_metrics.width,
-                            text_metrics.height
-                                * ((memchr_iter(b'\n', text.as_bytes()).count() as f64) * 1.15
-                                    + 1.0),
-                        ))
+                        Some(measure_text(render_context_2_d, &text, font.as_str(), *font_size))
                     }
                 })
             })
@@ -102,25 +85,14 @@ impl Layout for FixedSizeLayout {
                     .filter(|font_icon| !font_icon.is_empty())
                     .map(|font_icon| {
                         let icon_size = widget.get::<f64>("icon_size");
-                        let text_metrics = render_context_2_d.measure(
-                            &font_icon,
-                            *icon_size,
-                            widget.get::<String>("icon_font").as_str(),
-                        );
-                        (
-                            text_metrics.width,
-                            text_metrics.height
-                                * ((memchr_iter(b'\n', font_icon.as_bytes()).count() as f64)
-                                    * 1.15
-                                    + 1.0),
-                        )
+                        measure_text(render_context_2_d, &font_icon, widget.get::<String>("icon_font").as_str(), *icon_size)
                     })
             });
 
         if let Some(size) = size {
             if let Some(constraint) = component_try_mut::<Constraint>(ecm, entity, "constraint") {
-                constraint.set_width(size.0 as f64);
-                constraint.set_height(size.1 as f64);
+                constraint.set_width(size.width());
+                constraint.set_height(size.height());
             }
         }
 
@@ -208,4 +180,40 @@ fn text(widget: &WidgetContainer) -> Option<String> {
     }
 
     None
+}
+
+fn measure_text(render_context_2_d: &mut RenderContext2D, text: &str, font_family: &str, font_size: f64) -> Size {
+    let mut text_metrics = render_context_2_d.measure(
+        text,
+        font_size,
+        font_family,
+    );
+    let mut lines_iter = memchr_iter(b'\n', text.as_bytes()).chain(iter::once(text.len()));
+    let mut lines = SmallVec::<[(&str, usize); 2]>::new();
+    let mut last_hit = 0;
+    while let Some(hit) = lines_iter.next() {
+        let line = &text[last_hit..hit];
+        lines.push((line, UnicodeWidthStr::width(line)));
+        last_hit = hit;
+    }
+    let max_unicode_width = lines.iter().fold(0, |r, x| r.max(x.1));
+    text_metrics.width = 0.0;
+    for (line, width) in lines.iter() {
+        if *width != max_unicode_width {
+            continue;
+        }
+        let line_text_metrics = render_context_2_d.measure(
+            line,
+            font_size,
+            font_family,
+        );
+        text_metrics.width = text_metrics.width.max(line_text_metrics.width);
+    }
+    Size::new(
+        text_metrics.width,
+        text_metrics.height
+            * (((lines.len()-1) as f64)
+                * 1.15
+                + 1.0),
+    )
 }

--- a/crates/api/src/properties/mod.rs
+++ b/crates/api/src/properties/mod.rs
@@ -1,6 +1,6 @@
 //! This sub module contains extra structs used as widget properties.
 
-use std::{collections::HashSet, fmt::Debug};
+use std::{collections::HashSet, fmt::Debug, path::PathBuf};
 
 use dces::prelude::{Component, Entity, StringComponentStore};
 
@@ -86,6 +86,8 @@ into_property_source!(f32: utils::Value);
 into_property_source!(f64: i32, f32, utils::Value);
 into_property_source!(i32);
 into_property_source!(i64);
+
+into_property_source!(PathBuf);
 
 // Implementation of PropertySource for utils types
 into_property_source!(utils::Alignment: &str);


### PR DESCRIPTION
# Context:
There was a bug in the layout at the moment of calc the width of a `TextBlock` if it was multiline, this fixes that and also implements `IntoPropertySource` for `PathBuf` so now is possible use it as a widget property.