### PR TITLE
Add change_into() method

### DIFF
--- a/crates/api/src/widget_base/context.rs
+++ b/crates/api/src/widget_base/context.rs
@@ -62,6 +62,12 @@ impl<'a> Context<'a> {
         self.entity
     }
 
+    /// Changes the current `Context` into `another` widget's context.
+    /// Don't forget to change back to the original context after done using the altered context.
+    pub fn change_into(&mut self, another: Entity) {
+        self.entity = another;
+    }
+
     /// Access the raw window handle. Could be `None` on unsupported raw-window-handle platforms like `Redox`.
     pub fn raw_window_handle(&self) -> Option<RawWindowHandle> {
         if let Some(handle) = self.provider.raw_window_handle {


### PR DESCRIPTION
# Context:
Commit a338c852cb5acf62081089f1adbfa0d0c80a3698 made private the entity member of the Context struct and introduced the entity() getter method().
It broke my app, because it is used to change into another widget's context to do stuff.
This PR fixes this.

Reference to a related issue in the repository.
@FloVanGH

## Contribution checklist:
- [X] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
