### PR TITLE
widgets/popup: add the KeyDownHandler

### DIFF
--- a/crates/widgets/src/popup.rs
+++ b/crates/widgets/src/popup.rs
@@ -47,7 +47,7 @@ impl State for PopupState {
 
 widget!(
     /// The `Popup` is used to display content that floats over the main content.
-    Popup<PopupState> : MouseHandler {
+    Popup<PopupState> : KeyDownHandler, MouseHandler {
         /// Sets or shares the background property.
         background: Brush,
 


### PR DESCRIPTION
Signed-off-by: Ralf Zerres <ralf.zerres@networkx.de>

# Context:
If you need to handle Key events inside a popup widget, we can enable the KeyDownHandler as a default behaviour of the widget.

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
