### PR TITLE
Fix typos in links to subcrates in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,8 +389,8 @@ To build and run the latest version of the OrbTk manual check: [Manual](https://
 * [api](https://github.com/redox-os/orbtk/tree/develop/crates/api): base api elements of OrbTk e.g. widget and application parts
 * [proc_macros](https://github.com/redox-os/orbtk/tree/develop/crates/proc_macros): procedural helper macros
 * [render](https://github.com/redox-os/orbtk/tree/develop/crates/render): cross platform 2D/3D render library
-* [shell](https://github.com/redox-os/orbtk/tree/develop/crates/api): cross platform window and event handling
-* [theming](https://github.com/redox-os/orbtk/tree/develop/crates/theme): provide mechanism to style OrbTk UI's in rust and ron (replaces css-engine)
+* [shell](https://github.com/redox-os/orbtk/tree/develop/crates/shell): cross platform window and event handling
+* [theming](https://github.com/redox-os/orbtk/tree/develop/crates/theming): provide mechanism to style OrbTk UI's in rust and ron (replaces css-engine)
 * [tree](https://github.com/redox-os/orbtk/tree/develop/crates/tree): tree structure based on DCES
 * [utils](https://github.com/redox-os/orbtk/tree/develop/crates/utils): helper structs and traits
 * [widgets](https://github.com/redox-os/orbtk/tree/develop/crates/widgets): base widget library


### PR DESCRIPTION
# Context:
Found 2 dead links among the subcrates in readme.md.

Reference to a related issue in the repository.
@mentions of the person or team responsible for reviewing proposed changes.

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
