### PR TITLE
fix README.md, widgets' example has been removed on 25798a7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "orbclient"
 version = "0.3.28"
-source = "git+https://gitlab.redox-os.org/redox-os/orbclient.git?branch=master#fdff45e77693995d636a1e07a3a05052bb287a88"
+source = "git+https://gitlab.redox-os.org/redox-os/orbclient.git#fdff45e77693995d636a1e07a3a05052bb287a88"
 dependencies = [
  "libc",
  "raw-window-handle",

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ At the moment will evaluate different backends for OrbTk. A OrbTk backend consis
 
 ### miniraq
 
-* use with `miniraq` feature `cargo run --example widgets --features miniraq --no-default-features` 
+* use with `miniraq` feature `cargo run --example showcase --features miniraq --no-default-features` 
 * window and events based on [minifb](https://github.com/emoon/rust_minifb)
 * 2D rendering based on [raqote](https://github.com/jrmuizel/raqote)
 * Dependencies on Linux: libxkbcommon-dev, libwayland-cursor0, libwayland-dev


### PR DESCRIPTION
# Context:

widgets' example has been removed on 25798a7

```
$ cargo run --example widgets --features miniraq --no-default-features
error: no example target named `widgets`
```

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
