### PR TITLE
Support Alignment in theme files

### DIFF
--- a/crates/api/src/widget_base/widget_container.rs
+++ b/crates/api/src/widget_base/widget_container.rs
@@ -488,6 +488,8 @@ impl<'a> WidgetContainer<'a> {
                             self.update_value::<Thickness, Value>(&key, Value(value));
                         } else if self.is::<String>(&key) {
                             self.update_value::<String, Value>(&key, Value(value));
+                        } else if self.is::<Alignment>(&key) {
+                            self.update_value::<Alignment, Value>(&key, Value(value));
                         }
                     }
                 }

--- a/crates/utils/src/alignment.rs
+++ b/crates/utils/src/alignment.rs
@@ -1,3 +1,5 @@
+use crate::Value;
+
 /// Used to align a widget vertical or horizontal.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Alignment {
@@ -54,6 +56,19 @@ impl From<&str> for Alignment {
             "Start" | "start" => Alignment::Start,
             _ => Alignment::Stretch,
         }
+    }
+}
+
+impl From<String> for Alignment {
+    fn from(s: String) -> Alignment {
+        Self::from(&s[..])
+    }
+}
+
+impl From<Value> for Alignment {
+    fn from(v: Value) -> Self {
+        let value = v.get::<String>();
+        Alignment::from(value)
     }
 }
 
@@ -121,9 +136,15 @@ mod tests {
         );
     }
 
+    macro_rules! value {
+        ( $e:expr ) => {
+            Value(ron::Value::String(($e).to_string()))
+        };
+    }
+
     #[test]
     fn test_into() {
-        let alignment: Alignment = "start".into();
+        let alignment: Alignment = "Start".into();
         assert_eq!(alignment, Alignment::Start);
 
         let alignment: Alignment = "start".into();
@@ -135,7 +156,7 @@ mod tests {
         let alignment: Alignment = "center".into();
         assert_eq!(alignment, Alignment::Center);
 
-        let alignment: Alignment = "end".into();
+        let alignment: Alignment = "End".into();
         assert_eq!(alignment, Alignment::End);
 
         let alignment: Alignment = "end".into();
@@ -148,6 +169,33 @@ mod tests {
         assert_eq!(alignment, Alignment::Stretch);
 
         let alignment: Alignment = "other".into();
+        assert_eq!(alignment, Alignment::Stretch);
+
+        let alignment: Alignment = value!("Start").into();
+        assert_eq!(alignment, Alignment::Start);
+
+        let alignment: Alignment = value!("start").into();
+        assert_eq!(alignment, Alignment::Start);
+
+        let alignment: Alignment = value!("Center").into();
+        assert_eq!(alignment, Alignment::Center);
+
+        let alignment: Alignment = value!("center").into();
+        assert_eq!(alignment, Alignment::Center);
+
+        let alignment: Alignment = value!("End").into();
+        assert_eq!(alignment, Alignment::End);
+
+        let alignment: Alignment = value!("end").into();
+        assert_eq!(alignment, Alignment::End);
+
+        let alignment: Alignment = value!("Stretch").into();
+        assert_eq!(alignment, Alignment::Stretch);
+
+        let alignment: Alignment = value!("stretch").into();
+        assert_eq!(alignment, Alignment::Stretch);
+
+        let alignment: Alignment = value!("other").into();
         assert_eq!(alignment, Alignment::Stretch);
     }
 }

--- a/crates/utils/src/brush.rs
+++ b/crates/utils/src/brush.rs
@@ -112,14 +112,14 @@ use crate::prelude::*;
 /// Lets look at some examples. The first one shows the
 /// structure of an angled gradient
 ///
-/// ```
+/// ```text
 /// [repeating-]linear-gradient({Gradient-angle}{deg|rad|turn}, ...) [{X Displacement}px {Y Displacement}px], {Color} [{Stop  position}{%|px}]
 /// ```
 ///
 /// The next example shows the structure of a gradient that will be
 /// rendered in a given direction
 ///
-/// ```
+/// ```text
 /// [repeating-]linear-gradient({direction-identifier}, {initial color-name}, {terminating color-name}
 /// ```
 ///

--- a/crates/utils/src/point.rs
+++ b/crates/utils/src/point.rs
@@ -6,9 +6,10 @@ use std::ops::{Add, Div, Mul, Neg};
 ///
 /// # Examples
 /// ```rust
+/// # use orbtk_utils::Point;
 /// let point = Point::new(10., 10.);
 /// let other_point = Point::new(5., 7.);
-/// let result = size - other_point;
+/// let result = point - other_point;
 ///
 /// assert_eq!(result.x(), 5.);
 /// assert_eq!(result.y(), 3.);

--- a/crates/utils/src/rectangle.rs
+++ b/crates/utils/src/rectangle.rs
@@ -4,6 +4,7 @@ use crate::{Point, Size};
 ///
 /// # Examples
 /// ```rust
+/// # use orbtk_utils::Rectangle;
 /// let rectangle = Rectangle::new((0., 5.),(10., 7.));
 ///
 /// assert_eq!(rectangle.x(), 0.);

--- a/crates/utils/src/size.rs
+++ b/crates/utils/src/size.rs
@@ -5,6 +5,7 @@ use std::ops::Div;
 ///
 /// # Examples
 /// ```rust
+/// # use orbtk_utils::Size;
 /// let size = Size::new(10., 10.);
 /// let other_size = Size::new(5., 7.);
 /// let result = size - other_size;


### PR DESCRIPTION
# Context:
Alignments such as `h_align` and `v_align` must currently be set on widgets directly instead of being set by the theme. This PR allows Alignment to be set in themes.

## Contribution checklist:
- [x] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [x] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
