### PR TITLE
fix showcase project : Plural Planner url

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ There is a (wip) OrbTk book check [OrbTk book](https://github.com/redox-os/orbtk
 
 ## Showcases
 
-* [Plural Planner](https://codeberg.org/PluralTools/Planner): Task app
+* [Plural Planner](https://codeberg.org/PluralTools/Plural): Task app
 * [Kanter](https://github.com/lukors/kanter): Node based texture editor 
 * [twin-commander](https://github.com/kivimango/twin-commander): A twin-panel file manager specifically for the Redox OS 
 * [Space Editor](https://codeberg.org/flovanco/space-editor): 2D Tile Map Editor compatible with OrbGame


### PR DESCRIPTION
Plural Planner project url is changed, 
old:   https://codeberg.org/PluralTools/Planner
new: https://codeberg.org/PluralTools/Plural

# Context:
A description of the changes proposed in the pull request.

Reference to a related issue in the repository.
@mentions of the person or team responsible for reviewing proposed changes.

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [ ] Run `cargo fmt` to make the formatting consistent across the codebase
- [ ] Run `cargo clippy` to check with the linter
