### PR TITLE
documentation update

### DIFF
--- a/crates/api/src/widget_base/context.rs
+++ b/crates/api/src/widget_base/context.rs
@@ -63,8 +63,8 @@ impl<'a> Context<'a> {
         self.entity
     }
 
-    /// Changes the current `Context` into `another` widget's context.
-    /// Don't forget to change back to the original context after done using the altered context.
+    /// Switch current `Context` to context of given widget `another`.
+    /// Don't forget to change back to the original context once you are done.
     pub fn change_into(&mut self, another: Entity) {
         self.entity = another;
     }

--- a/crates/widgets/src/pager.rs
+++ b/crates/widgets/src/pager.rs
@@ -91,8 +91,8 @@ widget!(
     /// let next_button = Button::new()
     ///     .enabled(("next_enabled", pager))
     ///     .text("next")
-    ///     .on_click(move |ctx, _| {
-    ///         ctx.send_message(PagerAction::Next, pager);
+    ///     .on_click(move |states, _| {
+    ///         states.send_message(PagerAction::Next, pager);
     ///         true
     ///     })
     ///     .build(ctx);
@@ -101,7 +101,7 @@ widget!(
     ///     .enabled(("previous_enabled", pager))
     ///     .text("previous")
     ///     .on_click(move |states, _| {
-    ///         ctx.send_message(PagerAction::Next, pager);
+    ///         states.send_message(PagerAction::Previous, pager);
     ///         true
     ///     })
     ///     .build(ctx);


### PR DESCRIPTION
# Context:
Documentation update

api: description clarification when switching entitycontext with `change_into`
widgets: typo correction in `pager`
