### PR TITLE
Use reference-counted stylesheet when rendering

### DIFF
--- a/crates/api/src/application/mod.rs
+++ b/crates/api/src/application/mod.rs
@@ -25,7 +25,7 @@ pub struct Application {
     request_sender: mpsc::Sender<ShellRequest<WindowAdapter>>,
     shell: Shell<WindowAdapter>,
     name: Box<str>,
-    theme: Theme,
+    theme: Rc<Theme>,
     localization: Option<Rc<RefCell<Box<dyn Localization>>>>,
 }
 
@@ -43,7 +43,7 @@ impl Application {
 
     /// Sets the default theme for the application. Could be changed per window.
     pub fn theme(mut self, theme: Theme) -> Self {
-        self.theme = theme;
+        self.theme = Rc::new(theme);
         self
     }
 
@@ -63,7 +63,7 @@ impl Application {
             request_sender: sender,
             name: name.into(),
             shell: Shell::new(receiver),
-            theme: crate::theme_default::theme_default(),
+            theme: Rc::new(crate::theme_default::theme_default()),
             localization: None,
         }
     }
@@ -72,7 +72,7 @@ impl Application {
     pub fn window<F: Fn(&mut BuildContext) -> Entity + 'static>(mut self, create_fn: F) -> Self {
         let (adapter, settings, receiver) = create_window(
             self.name.clone(),
-            self.theme.clone(),
+            &self.theme,
             self.request_sender.clone(),
             create_fn,
             self.localization.clone(),

--- a/crates/api/src/application/window_adapter.rs
+++ b/crates/api/src/application/window_adapter.rs
@@ -204,7 +204,7 @@ impl shell::WindowAdapter for WindowAdapter {
 /// Creates a `WindowAdapter` and a `WindowSettings` object from a window builder closure.
 pub fn create_window<F: Fn(&mut BuildContext) -> Entity + 'static>(
     app_name: impl Into<String>,
-    theme: Theme,
+    theme: &Rc<Theme>,
     request_sender: mpsc::Sender<ShellRequest<WindowAdapter>>,
     create_fn: F,
     localization: Option<Rc<RefCell<Box<dyn Localization>>>>,
@@ -316,7 +316,7 @@ pub fn create_window<F: Fn(&mut BuildContext) -> Entity + 'static>(
     world
         .entity_component_manager()
         .component_store_mut()
-        .register("theme", window, theme);
+        .register("theme", window, Rc::clone(&theme));
     world
         .entity_component_manager()
         .component_store_mut()

--- a/crates/api/src/render_object/mod.rs
+++ b/crates/api/src/render_object/mod.rs
@@ -32,7 +32,7 @@ pub trait RenderObject: Any {
         entity: Entity,
         ecm: &mut EntityComponentManager<Tree>,
         context_provider: &ContextProvider,
-        theme: &Theme,
+        theme: &Rc<Theme>,
         offsets: &mut BTreeMap<Entity, (f64, f64)>,
         debug: bool,
     ) {
@@ -105,7 +105,7 @@ pub trait RenderObject: Any {
             entity,
             ecm,
             context_provider,
-            theme,
+            &theme,
             offsets,
             debug,
         );
@@ -140,7 +140,7 @@ pub trait RenderObject: Any {
         entity: Entity,
         ecm: &mut EntityComponentManager<Tree>,
         context_provider: &ContextProvider,
-        theme: &Theme,
+        theme: &Rc<Theme>,
         offsets: &mut BTreeMap<Entity, (f64, f64)>,
         debug: bool,
     ) {
@@ -153,7 +153,7 @@ pub trait RenderObject: Any {
                     child,
                     ecm,
                     context_provider,
-                    theme,
+                    &theme,
                     offsets,
                     debug,
                 );

--- a/crates/api/src/systems/cleanup_system.rs
+++ b/crates/api/src/systems/cleanup_system.rs
@@ -21,7 +21,7 @@ impl System<Tree, RenderContext2D> for CleanupSystem {
         let root = ecm.entity_store().root();
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 

--- a/crates/api/src/systems/event_state_system.rs
+++ b/crates/api/src/systems/event_state_system.rs
@@ -77,7 +77,7 @@ impl EventStateSystem {
     fn remove_widget(
         &self,
         entity: Entity,
-        theme: &Theme,
+        theme: &Rc<Theme>,
         ecm: &mut EntityComponentManager<Tree>,
         render_context: &mut RenderContext2D,
     ) {
@@ -159,7 +159,7 @@ impl EventStateSystem {
 
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 
@@ -502,7 +502,7 @@ impl System<Tree, RenderContext2D> for EventStateSystem {
 
             let theme = ecm
                 .component_store()
-                .get::<Theme>("theme", root)
+                .get::<Rc<Theme>>("theme", root)
                 .unwrap()
                 .clone();
 

--- a/crates/api/src/systems/init_system.rs
+++ b/crates/api/src/systems/init_system.rs
@@ -35,7 +35,7 @@ impl System<Tree, RenderContext2D> for InitSystem {
         // init css ids
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 

--- a/crates/api/src/systems/layout_system.rs
+++ b/crates/api/src/systems/layout_system.rs
@@ -36,7 +36,7 @@ impl System<Tree, RenderContext2D> for LayoutSystem {
 
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 

--- a/crates/api/src/systems/post_layout_state_system.rs
+++ b/crates/api/src/systems/post_layout_state_system.rs
@@ -15,7 +15,7 @@ impl PostLayoutStateSystem {
     fn remove_widget(
         &self,
         entity: Entity,
-        theme: &Theme,
+        theme: &Rc<Theme>,
         ecm: &mut EntityComponentManager<Tree>,
         render_context: &mut RenderContext2D,
     ) {
@@ -63,7 +63,7 @@ impl System<Tree, RenderContext2D> for PostLayoutStateSystem {
 
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 

--- a/crates/api/src/systems/render_system.rs
+++ b/crates/api/src/systems/render_system.rs
@@ -48,7 +48,7 @@ impl System<Tree, RenderContext2D> for RenderSystem {
         let root = ecm.entity_store().root();
         let theme = ecm
             .component_store()
-            .get::<Theme>("theme", root)
+            .get::<Rc<Theme>>("theme", root)
             .unwrap()
             .clone();
 

--- a/crates/api/src/widget_base/context.rs
+++ b/crates/api/src/widget_base/context.rs
@@ -23,7 +23,7 @@ use super::WidgetContainer;
 pub struct Context<'a> {
     pub(crate) ecm: &'a mut EntityComponentManager<Tree>,
     entity: Entity,
-    pub theme: Theme,
+    pub theme: Rc<Theme>,
     pub(crate) provider: &'a ContextProvider,
     new_states: BTreeMap<Entity, Box<dyn State>>,
     remove_widget_list: Vec<Entity>,
@@ -43,14 +43,14 @@ impl<'a> Context<'a> {
     /// Creates a new container.
     pub fn new(
         ecs: (Entity, &'a mut EntityComponentManager<Tree>),
-        theme: &Theme,
+        theme: &Rc<Theme>,
         provider: &'a ContextProvider,
         render_context: &'a mut RenderContext2D,
     ) -> Self {
         Context {
             entity: ecs.0,
             ecm: ecs.1,
-            theme: theme.clone(),
+            theme: Rc::clone(&theme),
             provider,
             new_states: BTreeMap::new(),
             remove_widget_list: vec![],
@@ -424,7 +424,7 @@ impl<'a> Context<'a> {
     pub fn show_window<F: Fn(&mut BuildContext) -> Entity + 'static>(&mut self, create_fn: F) {
         let (adapter, settings, receiver) = create_window(
             self.provider.application_name.clone(),
-            self.theme.clone(),
+            &self.theme,
             self.provider.shell_sender.clone(),
             create_fn,
             self.provider.localization.clone(),
@@ -446,10 +446,10 @@ impl<'a> Context<'a> {
     }
 
     /// Switch the current theme.
-    pub fn switch_theme(&mut self, theme: Theme) {
-        self.theme = theme.clone();
+    pub fn switch_theme(&mut self, theme: Rc<Theme>) {
+        self.theme = Rc::clone(&theme);
 
-        *self.window().get_mut::<Theme>("theme") = theme;
+        *self.window().get_mut::<Rc<Theme>>("theme") = theme;
 
         for (key, font) in self.theme.fonts() {
             self.render_context.register_font(key, *font);

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -795,11 +795,11 @@ impl State for InteractiveState {
                     let theme_index = *InteractiveView::selected_index_ref(&ctx.widget());
 
                     match theme_index {
-                        0 => ctx.switch_theme(theme_default_dark()),
-                        1 => ctx.switch_theme(theme_default_light()),
-                        2 => ctx.switch_theme(theme_redox()),
-                        3 => ctx.switch_theme(theme_fluent_dark()),
-                        4 => ctx.switch_theme(theme_fluent_light()),
+                        0 => ctx.switch_theme(Rc::new(theme_default_dark())),
+                        1 => ctx.switch_theme(Rc::new(theme_default_light())),
+                        2 => ctx.switch_theme(Rc::new(theme_redox())),
+                        3 => ctx.switch_theme(Rc::new(theme_fluent_dark())),
+                        4 => ctx.switch_theme(Rc::new(theme_fluent_light())),
                         _ => {}
                     }
                 }


### PR DESCRIPTION
# Context:

First of all, I'm new to Rust -- I spent a bit of time poking around the available GUI libraries out of curiousity. @FloVanGH, I must say that it was relatively easy to find my way around the codebase, and you guys have done a great job!

In #408 @ngortheone attached a [flamegraph](https://github.com/redox-os/orbtk/issues/408#issuecomment-735486445) which showed a lot of allocations and clones taking place during the update and render operations.

One of the ways we could avoid those clones (I believe we aren't crossing any thread boundaries) might be to share a single allocation of the theme and its stylesheet.

It seemed like low-hanging fruit, so that's exactly what I did. Here's what changed:
+ `Context` takes ownership of the theme in `Context::switch_theme()`
+ `RenderObject::render()` makes use of the reference-counted theme stored
  in the Entity Component System
+ `RenderObject::render_children()` likewise passes immutable references to
  the theme
+ Updated `showcase` example to match


## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [ ] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter
