### PR TITLE
[WIP] calculate dirty region that needs to be redrawn

### DIFF
--- a/orbtk_core/src/application/window_adapter.rs
+++ b/orbtk_core/src/application/window_adapter.rs
@@ -49,6 +49,16 @@ impl WindowAdapter {
             .root
             .unwrap()
     }
+
+    fn dirty_region(&mut self) -> Option<Rectangle> {
+        let root = self.root();
+        self.world
+            .entity_component_manager()
+            .component_store()
+            .get::<Option<Rectangle>>("dirty_region", root)
+            .unwrap()
+            .clone()
+    }
 }
 
 impl shell::WindowAdapter for WindowAdapter {
@@ -171,8 +181,9 @@ impl shell::WindowAdapter for WindowAdapter {
             .push_event_direct(root, WindowEvent::ActiveChanged(active));
     }
 
-    fn run(&mut self, render_context: &mut render::RenderContext2D) {
+    fn run(&mut self, render_context: &mut render::RenderContext2D) -> Option<Rectangle> {
         self.world.run_with_context(render_context);
+        self.dirty_region()
     }
 
     fn file_drop_event(&mut self, file_name: String) {

--- a/orbtk_core/src/macros.rs
+++ b/orbtk_core/src/macros.rs
@@ -1,4 +1,4 @@
-pub use crate::{theming::*, utils::prelude::*};
+pub use crate::utils::prelude::*;
 pub use dces::prelude::*;
 
 #[macro_export]
@@ -117,6 +117,10 @@ macro_rules! widget {
             #[property(Filter)]
             on_changed_filter: Filter,
             changed_handler: ChangedEventHandler,
+            #[property(VisualRenderProperties)]
+            previous_render: VisualRenderProperties,
+            #[property(Option<Rectangle>)]
+            dirty_region: Option<Rectangle>,
             _empty: Option<RefCell<i32>>,
              $(
                 $(
@@ -461,6 +465,8 @@ macro_rules! widget {
                 ctx.register_property("type_id", entity, TypeId::of::<$widget>());
                 ctx.register_property("type_name", entity, std::any::type_name::<$widget>().to_string());
                 ctx.register_property("dirty", entity, false);
+                ctx.register_property("previous_render", entity, this.previous_render);
+                ctx.register_property("dirty_region", entity, this.dirty_region);
 
                 let mut constraint = this.constraint;
 

--- a/orbtk_orbclient/src/window_adapter.rs
+++ b/orbtk_orbclient/src/window_adapter.rs
@@ -1,7 +1,10 @@
 //! This module contains traits to inject custom logic into the window shell.
 
 use crate::render::RenderContext2D;
-use crate::{event::*, utils::Point};
+use crate::{
+    event::*,
+    utils::{Point, Rectangle},
+};
 
 /// The `WindowAdapter` represents the bridge to the `Shell` backend.
 /// It receives events from the `Window` and runs it's own logic.  
@@ -46,5 +49,7 @@ pub trait WindowAdapter {
     fn text_drop_event(&mut self, text: String);
 
     /// Runs the inner logic of the shell adapter.
-    fn run(&mut self, render_context: &mut RenderContext2D);
+    ///
+    /// It returns the dirty region that needs to be redrawn.
+    fn run(&mut self, render_context: &mut RenderContext2D) -> Option<Rectangle>;
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -51,3 +51,13 @@ mod text_baseline;
 mod thickness;
 mod value;
 mod visibility;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct VisualRenderProperties {
+    pub bounds: Rectangle,
+    pub background: Brush,
+    pub border_radius: f64,
+    pub border_thickness: Thickness,
+    pub border_brush: Brush,
+    pub visibility: Visibility,
+}


### PR DESCRIPTION
# Context:

The intention of this PR isn't to be merged, but rather to get input/start a discussion for creating a PR which then could be merged.

I'd like to introduce the concept of a dirty region. This is the area that contains all the parts that need to be redrawn after the render step. Things outside this area wouldn't need to be redrawn.

I tried to keep this PR quite minimal, in hope that it shows the idea good enough, so that people can help me with finding out, what a proper implementation of this feature would look like (e.g. it should probably be a list of regions and not only a single one). Please help.

### Background

The reason why I'd like to have this feature is, that I'd to use OrbTK to create UIs for the reMarkable, an e-ink device. You would render the full framebuffer, but then tell it to refresh only the parts that changed, hence the introduction of the dirty region.

I tried this PR with the culculator example and it successfully refreshes only the buttons if they are pressed.

I'd also like to thank you all for creating this library. Over the past few months (is it years already?) I looked into a good UI library that I could use for the reMarkable. I've tried out several ones, but the alternatives contain lots of abstractions which then leak through implementation details nonetheless . I like the approach OrbTK is currently taking, with rendering to a framebuffer, which is exactly what I need to get it working on a reMarkable. Thanks for switching to tiny-skia recently (which I've been [experimenting with](https://github.com/vmx/remtiski) on the reMarkable as well), that made it really easy for me.
