### PR TITLE
Extend showcase example

### DIFF
--- a/orbtk/examples/showcase.rs
+++ b/orbtk/examples/showcase.rs
@@ -3,6 +3,128 @@ use orbtk::{prelude::*, widgets::themes::*};
 // German localization file.
 static SHOWCASE_DE_DE: &str = include_str!("assets/showcase/showcase_de_DE.ron");
 
+// Constants
+static ID_BUTTON_GRID: &str = "ButtonGrid";
+static ID_BUTTON_STACK: &str = "ButtonStack";
+static ID_BUTTON_CHECK: &str = "ButtonCheck";
+static ID_BUTTON_DISABLE: &str = "ButtonDisable";
+static ID_BUTTON_PRIMARY: &str = "ButtonPrimary";
+static ID_BUTTON_SINGLE: &str = "ButtonSingle";
+static ID_BUTTON_TEXT: &str = "ButtonText";
+static ID_BUTTON_TOGGLE: &str = "ButtonToggle";
+static ID_CHECK_BOX: &str = "CheckBox";
+static ID_CHECK_BOX_DISABLED: &str = "CheckBoxDisabled";
+static ID_COMBO_BOX: &str = "ComboBox";
+static ID_COMBO_BOX_TEXT: &str = "ComboBoxText";
+static ID_IMAGE_WIDGET: &str = "ImageWidget";
+static ID_INTERACTIVE_VIEW: &str = "InteractiveView";
+static ID_INTERACTIVE_VIEW_BUTTON: &str = "InteractiveViewButton";
+static ID_INTERACTIVE_VIEW_BUTTON2: &str = "InteractiveViewButton2";
+static ID_INTERACTIVE_VIEW_BUTTON3: &str = "InteractiveViewButton3";
+static ID_INTERACTIVE_VIEW_BUTTON4: &str = "InteractiveViewButton4";
+static ID_INTERACTIVE_VIEW_COMBO_BOX: &str = "InteractiveViewComboBox";
+static ID_INTERACTIVE_VIEW_TEXT_BLOCK: &str = "InteractiveViewTextBlock";
+static ID_INTERACTIVE_VIEW_TEXT_BLOCK2: &str = "InteractiveViewTextBlock2";
+static ID_INTERACTIVE_VIEW_TEXT_BLOCK3: &str = "InteractiveViewTextBlock3";
+static ID_INTERACTIVE_VIEW_TEXT_BLOCK4: &str = "InteractiveViewTextBlock4";
+static ID_INTERACTIVE_VIEW_TEXT_BLOCK5: &str = "InteractiveViewTextBlock5";
+static ID_ITEMS_VIEW: &str = "ItemsView";
+static ID_ITEMS_VIEW_STACK: &str = "ItemsViewStack";
+static ID_ITEMS_VIEW_TEXT_BLOCK: &str = "ItemsViewHeader";
+static ID_ITEMS_VIEW_TEXT_BLOCK_HEADER: &str = "ItemsViewTextBlockHeader";
+static ID_ITEMS_VIEW_TEXT_BLOCK_HEADER_2: &str = "ItemsViewTextBlockHeader2";
+static ID_ITEMS_VIEW_ITEMS_WIDGET: &str = "ItemsWidgetBody";
+static ID_ITEMS_VIEW_ITEMS_WIDGET_TEXT_BLOCK: &str = "ItemsWidgetText";
+static ID_LAYOUT_VIEW: &str = "LayoutView";
+static ID_LAYOUT_VIEW_STACK: &str = "LayoutViewStack";
+static ID_LAYOUT_VIEW_STACK_TEXT_BLOCK: &str = "LayoutViewStackTextBlock";
+static ID_LAYOUT_VIEW_STACK_TEXT_BLOCK2: &str = "LayoutViewStackTextBlock2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER: &str = "LayoutViewStackContainer";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID: &str = "LayoutViewStackContainerGrid";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER: &str =
+    "LayoutViewStackContainerGridContainer";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER_TEXT_BLOCK: &str =
+    "LayoutViewStackContainerGridContainerTextBlock";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2: &str =
+    "LayoutViewStackContainerGridContainer2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2_TEXT_BLOCK: &str =
+    "LayoutViewStackContainerGridContainer2TextBlock";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3: &str =
+    "LayoutViewStackContainerGridContainer2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3_TEXT_BLOCK: &str =
+    "LayoutViewStackContainerGridContainer2TextBlock";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4: &str =
+    "LayoutViewStackContainerGridContainer2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4_TEXT_BLOCK: &str =
+    "LayoutViewStackContainerGridContainer2TextBlock";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2: &str = "LayoutViewStackContainer2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK: &str = "LayoutViewStackContainer2Stack";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER: &str =
+    "LayoutViewStackContainerStackContainer";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER2: &str =
+    "LayoutViewStackContainerStackContainer2";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER3: &str =
+    "LayoutViewStackContainerStackContainer3";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER4: &str =
+    "LayoutViewStackContainerStackContainer4";
+static ID_LAYOUT_VIEW_STACK_CONTAINER2_TEXT_BLOCK: &str = "LayoutViewStackContainer2TextBlock";
+static ID_LAYOUT_VIEW_STACK_CONTAINER3: &str = "LayoutViewStackContainer3";
+static ID_LAYOUT_VIEW_STACK_CONTAINER3_CONTAINER: &str = "LayoutViewStackContainer3Container";
+static ID_LIST_VIEW: &str = "ListView";
+static ID_LOCALIZATION_VIEW_STACK: &str = "LocalizationViewStack";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK: &str = "LocalizationViewStackTextBlock";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK2: &str = "LocalizationViewStackTextBlock2";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK3: &str = "LocalizationViewStackTextBlock3";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK4: &str = "LocalizationViewStackTextBlock4";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK5: &str = "LocalizationViewStackTextBlock5";
+static ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK6: &str = "LocalizationViewStackTextBlock6";
+static ID_LOCALIZATION_VIEW_STACK_COMBO_BOX: &str = "LocalizationViewStackComboBox";
+static ID_LOCALIZATION_VIEW_STACK_COMBO_BOX_TEXT_BLOCK: &str =
+    "LocalizationViewStackComboBoxTextBlock";
+static ID_MAIN_VIEW: &str = "MainView";
+static ID_NAVIGATION_VIEW: &str = "NavigationView";
+static ID_NAVIGATION_VIEW_GRID: &str = "NavigationViewPagerGrid";
+static ID_NAVIGATION_VIEW_GRID_BUTTON: &str = "NavigationViewPagerGridButton";
+static ID_NAVIGATION_VIEW_GRID_BUTTON2: &str = "NavigationViewPagerGridButton2";
+static ID_NAVIGATION_VIEW_GRID_TEXT_BLOCK: &str = "NavigationViewPagerGridTextBlock";
+static ID_NAVIGATION_VIEW_GRID_TEXT_BLOCK2: &str = "NavigationViewPagerGridTextBlock2";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL: &str = "NavigationViewPagerGridMasterDetail";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER: &str =
+    "NavigationViewGridMasterDetailContainer";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK: &str =
+    "NavigationViewGridMasterDetailContainerStack";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK: &str =
+    "NavigationViewGridMasterDetailContainerStackTextBlock";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK2: &str =
+    "NavigationViewGridMasterDetailContainerStackTextBlock2";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_TEXT_BLOCK: &str =
+    "NavigationViewGridMasterDetailContainerTextBlock";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_BUTTON: &str =
+    "NavigationViewGridMasterDetailContainerButton";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2: &str =
+    "NavigationViewGridMasterDetailContainer2";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_TEXT_BLOCK: &str =
+    "NavigationViewGridMasterDetailContainer2TextBlock";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_TEXT_BLOCK2: &str =
+    "NavigationViewGridMasterDetailContainer2TextBlock2";
+static ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_BUTTON: &str =
+    "NavigationViewGridMasterDetailContainer2Button";
+static ID_NAVIGATION_VIEW_PAGER: &str = "NavigationViewPager";
+static ID_NAVIGATION_VIEW_PAGER_CONTAINER: &str = "NavigationViewPagerContainer";
+static ID_NAVIGATION_VIEW_PAGER_CONTAINER2: &str = "NavigationViewPagerContainer2";
+static ID_NAVIGATION_VIEW_PAGER_CONTAINER3: &str = "NavigationViewPagerContainer3";
+static ID_PASSWORD_BOX: &str = "PasswordBox";
+static ID_PROGRESS_BAR: &str = "ProgressBar";
+static ID_SLIDER: &str = "Slider";
+static ID_SWITCH: &str = "Switch";
+static ID_SWITCH_DISABLED: &str = "SwitchDisabled";
+static ID_STACK: &str = "Stack";
+static ID_STACK_TEXT_BLOCK_HEADER: &str = "StackTextBLockHeader";
+static ID_STACK_TEXT_BLOCK_TEXT: &str = "StackTextBlockText";
+static ID_STACK_TEXT_BOX_WATER_MARK: &str = "StackTextBoxWaterMark";
+static ID_TAB_WIDGET: &str = "TabWidget";
+static ID_WINDOW: &str = "Window";
+
 fn main() {
     // if no dictionary is set for the default language e.g. english the content of the text property will drawn.
     let localization = RonLocalization::create()
@@ -15,11 +137,18 @@ fn main() {
         .localization(localization)
         .window(|ctx| {
             Window::new()
+                .id(ID_WINDOW)
+                .name(ID_WINDOW)
                 .title("OrbTk - showcase example")
                 .position((100, 100))
                 .size(1000, 730)
                 .resizeable(true)
-                .child(MainView::new().build(ctx))
+                .child(
+                    MainView::new()
+                        .id(ID_MAIN_VIEW)
+                        .name(ID_MAIN_VIEW)
+                        .build(ctx),
+                )
                 .build(ctx)
         })
         .run();
@@ -32,8 +161,10 @@ widget!(MainView {});
 
 impl Template for MainView {
     fn template(self, _id: Entity, ctx: &mut BuildContext) -> Self {
-        self.child(
+        self.id(ID_MAIN_VIEW).name(ID_MAIN_VIEW).child(
             TabWidget::new()
+                .id(ID_TAB_WIDGET)
+                .name(ID_TAB_WIDGET)
                 .tab("Buttons / Text", ButtonView::new().build(ctx))
                 .tab("Items", ItemsView::new().build(ctx))
                 .tab("Layouts", LayoutView::new().build(ctx))
@@ -51,16 +182,27 @@ widget!(ButtonView {});
 
 impl Template for ButtonView {
     fn template(self, _id: Entity, ctx: &mut BuildContext) -> Self {
-        let slider = Slider::new().min(0.0).max(1.0).build(ctx);
+        let slider = Slider::new()
+            .id(ID_SLIDER)
+            .name(ID_SLIDER)
+            .min(0.0)
+            .max(1.0)
+            .build(ctx);
         self.child(
             Grid::new()
+                .id(ID_BUTTON_GRID)
+                .name(ID_BUTTON_GRID)
                 .margin(16)
                 .columns("140, 32, 140")
                 .child(
                     Stack::new()
+                        .id(ID_BUTTON_STACK)
+                        .name(ID_BUTTON_STACK)
                         .spacing(8)
                         .child(
                             Button::new()
+                                .id(ID_BUTTON_CHECK)
+                                .name(ID_BUTTON_CHECK)
                                 .text("Button")
                                 .icon(material_icons_font::MD_CHECK)
                                 .on_enter(|_, _| {
@@ -73,6 +215,8 @@ impl Template for ButtonView {
                         )
                         .child(
                             Button::new()
+                                .id(ID_BUTTON_DISABLE)
+                                .name(ID_BUTTON_DISABLE)
                                 .enabled(false)
                                 .text("disabled")
                                 .icon(material_icons_font::MD_CHECK)
@@ -80,6 +224,8 @@ impl Template for ButtonView {
                         )
                         .child(
                             Button::new()
+                                .id(ID_BUTTON_PRIMARY)
+                                .name(ID_BUTTON_PRIMARY)
                                 .text("Primary")
                                 .style("button_primary")
                                 .icon(material_icons_font::MD_360)
@@ -87,39 +233,94 @@ impl Template for ButtonView {
                         )
                         .child(
                             Button::new()
+                                .id(ID_BUTTON_TEXT)
+                                .name(ID_BUTTON_TEXT)
                                 .text("Text only")
                                 .style("button_single_content")
                                 .build(ctx),
                         )
                         .child(
                             Button::new()
+                                .id(ID_BUTTON_SINGLE)
+                                .name(ID_BUTTON_SINGLE)
                                 .icon(material_icons_font::MD_CHECK)
                                 .style("button_single_content")
                                 .build(ctx),
                         )
                         .child(
                             ToggleButton::new()
+                                .id(ID_BUTTON_TOGGLE)
+                                .name(ID_BUTTON_TOGGLE)
                                 .text("ToggleButton")
                                 .icon(material_icons_font::MD_ALARM_ON)
                                 .build(ctx),
                         )
-                        .child(CheckBox::new().text("CheckBox").build(ctx))
-                        .child(CheckBox::new().enabled(false).text("disabled").build(ctx))
-                        .child(Switch::new().build(ctx))
-                        .child(Switch::new().enabled(false).build(ctx))
+                        .child(
+                            CheckBox::new()
+                                .id(ID_CHECK_BOX)
+                                .name(ID_CHECK_BOX)
+                                .text("CheckBox")
+                                .build(ctx),
+                        )
+                        .child(
+                            CheckBox::new()
+                                .id(ID_CHECK_BOX_DISABLED)
+                                .name(ID_CHECK_BOX_DISABLED)
+                                .enabled(false)
+                                .text("disabled")
+                                .build(ctx),
+                        )
+                        .child(Switch::new().id(ID_SWITCH).name(ID_SWITCH).build(ctx))
+                        .child(
+                            Switch::new()
+                                .id(ID_SWITCH_DISABLED)
+                                .name(ID_SWITCH_DISABLED)
+                                .enabled(false)
+                                .build(ctx),
+                        )
                         .child(slider)
-                        .child(ProgressBar::new().val(slider).build(ctx))
+                        .child(
+                            ProgressBar::new()
+                                .id(ID_PROGRESS_BAR)
+                                .name(ID_PROGRESS_BAR)
+                                .val(slider)
+                                .build(ctx),
+                        )
                         .build(ctx),
                 )
                 .child(
                     Stack::new()
+                        .id(ID_STACK)
+                        .name(ID_STACK)
                         .attach(Grid::column(2))
                         .spacing(8)
-                        .child(TextBlock::new().text("Header").style("header").build(ctx))
-                        .child(TextBlock::new().text("Text").style("body").build(ctx))
-                        .child(TextBox::new().water_mark("Insert text...").build(ctx))
+                        .child(
+                            TextBlock::new()
+                                .id(ID_STACK_TEXT_BLOCK_HEADER)
+                                .name(ID_STACK_TEXT_BLOCK_HEADER)
+                                .style("header")
+                                .text("Header")
+                                .build(ctx),
+                        )
+                        .child(
+                            TextBlock::new()
+                                .id(ID_STACK_TEXT_BLOCK_TEXT)
+                                .name(ID_STACK_TEXT_BLOCK_TEXT)
+                                .style("body")
+                                .text("Text")
+                                .build(ctx),
+                        )
+                        .child(
+                            TextBox::new()
+                                .id(ID_STACK_TEXT_BOX_WATER_MARK)
+                                .name(ID_STACK_TEXT_BOX_WATER_MARK)
+                                .water_mark("Insert text...")
+                                .build(ctx),
+                        )
                         .child(
                             PasswordBox::new()
+                                .id(ID_PASSWORD_BOX)
+                                .name(ID_PASSWORD_BOX)
                                 .water_mark("Insert password...")
                                 .build(ctx),
                         )
@@ -145,64 +346,90 @@ impl Template for ItemsView {
             "Item 5".to_string(),
         ];
         let count = items.len();
-        self.items(items).child(
-            Stack::new()
-                .width(140)
-                .margin(16)
-                .spacing(8)
-                .child(
-                    TextBlock::new()
-                        .text("ItemsWidget")
-                        .style("header")
-                        .build(ctx),
-                )
-                .child(
-                    ItemsWidget::new()
-                        .count(count)
-                        .items_builder(move |bc, index| {
-                            let text = bc.get_widget(id).get::<Vec<String>>("items")[index].clone();
-                            TextBlock::new()
-                                .style("body")
-                                .v_align("center")
-                                .text(text)
-                                .build(bc)
-                        })
-                        .build(ctx),
-                )
-                .child(TextBlock::new().text("ListView").style("header").build(ctx))
-                .child(
-                    ListView::new()
-                        .count(count)
-                        .items_builder(move |bc, index| {
-                            let text = bc.get_widget(id).get::<Vec<String>>("items")[index].clone();
-                            TextBlock::new().v_align("center").text(text).build(bc)
-                        })
-                        .build(ctx),
-                )
-                .child(TextBlock::new().text("ComboBox").style("header").build(ctx))
-                .child(
-                    ComboBox::new()
-                        .count(count)
-                        .items_builder(move |bc, index| {
-                            let text = ItemsView::items_ref(&bc.get_widget(id))[index].clone();
-                            TextBlock::new().v_align("center").text(text).build(bc)
-                        })
-                        .selected_index(0)
-                        .build(ctx),
-                )
-                .child(
-                    ComboBox::new()
-                        .enabled(false)
-                        .count(count)
-                        .items_builder(move |bc, index| {
-                            let text = ItemsView::items_ref(&bc.get_widget(id))[index].clone();
-                            TextBlock::new().v_align("center").text(text).build(bc)
-                        })
-                        .selected_index(0)
-                        .build(ctx),
-                )
-                .build(ctx),
-        )
+
+        self.id(ID_ITEMS_VIEW)
+            .name(ID_ITEMS_VIEW)
+            .items(items)
+            .child(
+                Stack::new()
+                    .id(ID_ITEMS_VIEW_STACK)
+                    .name(ID_ITEMS_VIEW_STACK)
+                    .width(140)
+                    .margin(16)
+                    .spacing(8)
+                    .child(
+                        TextBlock::new()
+                            .id(ID_ITEMS_VIEW_TEXT_BLOCK)
+                            .name(ID_ITEMS_VIEW_TEXT_BLOCK)
+                            .text("ItemsWidget")
+                            .style("header")
+                            .build(ctx),
+                    )
+                    .child(
+                        ItemsWidget::new()
+                            .id(ID_ITEMS_VIEW_ITEMS_WIDGET)
+                            .name(ID_ITEMS_VIEW_ITEMS_WIDGET)
+                            .count(count)
+                            .items_builder(move |bc, index| {
+                                let text =
+                                    bc.get_widget(id).get::<Vec<String>>("items")[index].clone();
+                                TextBlock::new()
+                                    .style("body")
+                                    .id(ID_ITEMS_VIEW_ITEMS_WIDGET_TEXT_BLOCK)
+                                    .name(ID_ITEMS_VIEW_ITEMS_WIDGET_TEXT_BLOCK)
+                                    .text(text)
+                                    .v_align("center")
+                                    .build(bc)
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        TextBlock::new()
+                            .id(ID_ITEMS_VIEW_TEXT_BLOCK_HEADER)
+                            .name(ID_ITEMS_VIEW_TEXT_BLOCK_HEADER)
+                            .style("header")
+                            .text("ListView")
+                            .build(ctx),
+                    )
+                    .child(
+                        ListView::new()
+                            .id(ID_LIST_VIEW)
+                            .name(ID_LIST_VIEW)
+                            .count(count)
+                            .items_builder(move |bc, index| {
+                                let text =
+                                    bc.get_widget(id).get::<Vec<String>>("items")[index].clone();
+                                TextBlock::new().v_align("center").text(text).build(bc)
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        TextBlock::new()
+                            .id(ID_ITEMS_VIEW_TEXT_BLOCK_HEADER_2)
+                            .name(ID_ITEMS_VIEW_TEXT_BLOCK_HEADER_2)
+                            .style("header")
+                            .text("ComboBox")
+                            .build(ctx),
+                    )
+                    .child(
+                        ComboBox::new()
+                            .id(ID_COMBO_BOX)
+                            .name(ID_COMBO_BOX)
+                            .count(count)
+                            .enabled(false)
+                            .items_builder(move |bc, index| {
+                                let text = ItemsView::items_ref(&bc.get_widget(id))[index].clone();
+                                TextBlock::new()
+                                    .id(ID_COMBO_BOX_TEXT)
+                                    .text(text)
+                                    .v_align("center")
+                                    .build(bc)
+                            })
+                            .selected_index(0)
+                            .build(ctx),
+                    )
+                    .build(ctx),
+            )
     }
 }
 
@@ -211,129 +438,186 @@ widget!(LayoutView {});
 
 impl Template for LayoutView {
     fn template(self, _id: Entity, ctx: &mut BuildContext) -> Self {
-        self.child(
-            Stack::new()
-                .width(400)
-                .margin(16)
-                .spacing(8)
-                .child(TextBlock::new().text("Grid").style("header").build(ctx))
-                .child(
-                    Container::new()
-                        .width(300)
-                        .height(150)
-                        .background("black")
-                        .child(
-                            Grid::new()
-                                .columns("*, auto, 50")
-                                .rows("*, *")
-                                .child(
-                                    Container::new()
-                                        .background("lynch")
-                                        .margin((10, 0, 0, 4))
-                                        .attach(Grid::column(0))
-                                        .child(
-                                            TextBlock::new()
-                                                .text("(0,0)")
-                                                .style("light_text")
-                                                .h_align("center")
-                                                .v_align("center")
-                                                .build(ctx),
-                                        )
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Container::new()
-                                        .background("bluebayoux")
-                                        .margin(10)
-                                        .constraint(Constraint::create().width(150))
-                                        .attach(Grid::column(1))
-                                        .child(
-                                            TextBlock::new()
-                                                .text("(1,0)")
-                                                .style("body")
-                                                .h_align("center")
-                                                .v_align("center")
-                                                .build(ctx),
-                                        )
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Container::new()
-                                        .background("linkwater")
-                                        .attach(Grid::column(2))
-                                        .child(
-                                            TextBlock::new()
-                                                .text("(2,0)")
-                                                .foreground("black")
-                                                .h_align("center")
-                                                .v_align("center")
-                                                .build(ctx),
-                                        )
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Container::new()
-                                        .background("goldendream")
-                                        .attach(Grid::column(0))
-                                        .attach(Grid::row(1))
-                                        .attach(Grid::column_span(3))
-                                        .child(
-                                            TextBlock::new()
-                                                .text("(0,1) - ColumnSpan 3")
-                                                .foreground("black")
-                                                .h_align("center")
-                                                .v_align("center")
-                                                .build(ctx),
-                                        )
-                                        .build(ctx),
-                                )
-                                .build(ctx),
-                        )
-                        .build(ctx),
-                )
-                .child(TextBlock::new().text("Stack").style("header").build(ctx))
-                .child(
-                    Container::new()
-                        .background("black")
-                        .width(300)
-                        .child(
-                            Stack::new()
-                                .spacing(4)
-                                .child(Container::new().background("lynch").height(50).build(ctx))
-                                .child(
-                                    Container::new()
-                                        .background("bluebayoux")
-                                        .height(50)
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Container::new()
-                                        .background("linkwater")
-                                        .height(50)
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Container::new()
-                                        .background("goldendream")
-                                        .height(50)
-                                        .build(ctx),
-                                )
-                                .build(ctx),
-                        )
-                        .build(ctx),
-                )
-                .child(TextBlock::new().text("Padding").style("header").build(ctx))
-                .child(
-                    Container::new()
-                        .background("black")
-                        .width(300)
-                        .height(150)
-                        .padding((16, 8, 16, 8))
-                        .child(Container::new().background("lynch").build(ctx))
-                        .build(ctx),
-                )
-                .build(ctx),
-        )
+        self.id(ID_LAYOUT_VIEW)
+            .name(ID_LAYOUT_VIEW)
+            .child(
+                Stack::new()
+                    .id(ID_LAYOUT_VIEW_STACK)
+                    .name(ID_LAYOUT_VIEW_STACK)
+                    .width(400)
+                    .margin(16)
+                    .spacing(8)
+                    .child(TextBlock::new()
+                           .id(ID_LAYOUT_VIEW_STACK_TEXT_BLOCK)
+                           .name(ID_LAYOUT_VIEW_STACK_TEXT_BLOCK)
+                           .style("header")
+                           .text("Grid")
+                           .build(ctx))
+                    .child(
+                        Container::new()
+                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER)
+                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER)
+                            .width(300)
+                            .height(150)
+                            .background("black")
+                            .child(
+                                Grid::new()
+                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID)
+                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID)
+                                    .columns("*, auto, 50")
+                                    .rows("*, *")
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER)
+                                            .background("lynch")
+                                            .margin((10, 0, 0, 4))
+                                            .attach(Grid::column(0))
+                                            .child(
+                                                TextBlock::new()
+                                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER_TEXT_BLOCK)
+                                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER_TEXT_BLOCK)
+                                                    .text("(0,0)")
+                                                    .style("light_text")
+                                                    .h_align("center")
+                                                    .v_align("center")
+                                                    .build(ctx),
+                                            )
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2)
+                                            .background("bluebayoux")
+                                            .margin(10)
+                                            .constraint(Constraint::create().width(150))
+                                            .attach(Grid::column(1))
+                                            .child(
+                                                TextBlock::new()
+                                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2_TEXT_BLOCK)
+                                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER2_TEXT_BLOCK)
+                                                    .text("(1,0)")
+                                                    .style("body")
+                                                    .h_align("center")
+                                                    .v_align("center")
+                                                    .build(ctx),
+                                            )
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3)
+                                            .background("linkwater")
+                                            .attach(Grid::column(2))
+                                            .child(
+                                                TextBlock::new()
+                                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3_TEXT_BLOCK)
+                                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER3_TEXT_BLOCK)
+                                                    .text("(2,0)")
+                                                    .foreground("black")
+                                                    .h_align("center")
+                                                    .v_align("center")
+                                                    .build(ctx),
+                                            )
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4)
+                                            .background("goldendream")
+                                            .attach(Grid::column(0))
+                                            .attach(Grid::row(1))
+                                            .attach(Grid::column_span(3))
+                                            .child(
+                                                TextBlock::new()
+                                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4_TEXT_BLOCK)
+                                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER_GRID_CONTAINTER4_TEXT_BLOCK)
+                                                    .text("(0,1) - ColumnSpan 3")
+                                                    .foreground("black")
+                                                    .h_align("center")
+                                                    .v_align("center")
+                                                    .build(ctx),
+                                            )
+                                            .build(ctx),
+                                    )
+                                    .build(ctx),
+                            )
+                            .build(ctx),
+                    )
+                    .child(TextBlock::new()
+                           .id(ID_LAYOUT_VIEW_STACK_TEXT_BLOCK2)
+                           .name(ID_LAYOUT_VIEW_STACK_TEXT_BLOCK2)
+                           .style("header")
+                           .text("Stack")
+                           .build(ctx))
+                    .child(
+                        Container::new()
+                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER2)
+                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER2)
+                            .background("black")
+                            .width(300)
+                            .child(
+                                Stack::new()
+                                    .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK)
+                                    .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK)
+                                    .spacing(4)
+                                    .child(Container::new()
+                                           .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER)
+                                           .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER)
+                                           .background("lynch").height(50).build(ctx))
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER2)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER2)
+                                            .background("bluebayoux")
+                                            .height(50)
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER3)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER3)
+                                            .background("linkwater")
+                                            .height(50)
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Container::new()
+                                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER4)
+                                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_STACK_CONTAINER4)
+                                            .background("goldendream")
+                                            .height(50)
+                                            .build(ctx),
+                                    )
+                                    .build(ctx),
+                            )
+                            .build(ctx),
+                    )
+                    .child(TextBlock::new()
+                           .id(ID_LAYOUT_VIEW_STACK_CONTAINER2_TEXT_BLOCK)
+                           .name(ID_LAYOUT_VIEW_STACK_CONTAINER2_TEXT_BLOCK)
+                           .style("header")
+                           .text("Padding")
+                           .build(ctx))
+                    .child(
+                        Container::new()
+                            .id(ID_LAYOUT_VIEW_STACK_CONTAINER3)
+                            .name(ID_LAYOUT_VIEW_STACK_CONTAINER3)
+                            .background("black")
+                            .width(300)
+                            .height(150)
+                            .padding((16, 8, 16, 8))
+                            .child(Container::new()
+                                   .id(ID_LAYOUT_VIEW_STACK_CONTAINER3_CONTAINER)
+                                   .background("lynch")
+                                   .build(ctx))
+                            .build(ctx),
+                    )
+                    .build(ctx),
+            )
     }
 }
 
@@ -344,6 +628,8 @@ impl Template for ImageView {
     fn template(self, _id: Entity, ctx: &mut BuildContext) -> Self {
         self.child(
             ImageWidget::new()
+                .id(ID_IMAGE_WIDGET)
+                .name(ID_IMAGE_WIDGET)
                 .margin(16)
                 .image("orbtk/examples/assets/showcase/orbtk_logo.png")
                 .build(ctx),
@@ -361,37 +647,73 @@ impl Template for LocalizationView {
 
         self.languages(languages).selected_index(0).child(
             Stack::new()
+                .id(ID_LOCALIZATION_VIEW_STACK)
+                .name(ID_LOCALIZATION_VIEW_STACK)
                 .width(120)
                 .margin(16)
                 .spacing(8)
                 .child(
                     TextBlock::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK)
                         .style("small_text")
                         .text("Hello")
                         .build(ctx),
                 )
                 .child(
                     TextBlock::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK2)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK2)
                         .style("small_text")
                         .text("world")
                         .build(ctx),
                 )
-                .child(TextBlock::new().style("small_text").text("I").build(ctx))
-                .child(TextBlock::new().style("small_text").text("love").build(ctx))
+                .child(
+                    TextBlock::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK3)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK3)
+                        .style("small_text")
+                        .text("I")
+                        .build(ctx),
+                )
+                .child(
+                    TextBlock::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK4)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK4)
+                        .style("small_text")
+                        .text("love")
+                        .build(ctx),
+                )
                 .child(
                     TextBlock::new()
                         .style("small_text")
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK5)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK5)
                         .text("localization")
                         .build(ctx),
                 )
-                .child(TextBlock::new().style("small_text").text("!").build(ctx))
+                .child(
+                    TextBlock::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK6)
+                        .name(ID_LOCALIZATION_VIEW_STACK_TEXT_BLOCK6)
+                        .style("small_text")
+                        .text("!")
+                        .build(ctx),
+                )
                 .child(
                     ComboBox::new()
+                        .id(ID_LOCALIZATION_VIEW_STACK_COMBO_BOX)
+                        .name(ID_LOCALIZATION_VIEW_STACK_COMBO_BOX)
                         .count(count)
                         .items_builder(move |bc, index| {
                             let text =
                                 LocalizationView::languages_ref(&bc.get_widget(id))[index].clone();
-                            TextBlock::new().v_align("center").text(text).build(bc)
+                            TextBlock::new()
+                                .id(ID_LOCALIZATION_VIEW_STACK_COMBO_BOX_TEXT_BLOCK)
+                                .name(ID_LOCALIZATION_VIEW_STACK_COMBO_BOX_TEXT_BLOCK)
+                                .v_align("center")
+                                .text(text)
+                                .build(bc)
                         })
                         .on_changed("selected_index", move |states, _| {
                             states.get_mut::<LocalizationState>(id).change_language();
@@ -414,9 +736,12 @@ widget!(
 impl Template for NavigationView {
     fn template(self, id: Entity, ctx: &mut BuildContext) -> Self {
         let pager = Pager::new()
+            .id(ID_NAVIGATION_VIEW_PAGER)
             .attach(Grid::row(1))
             .child(
                 Container::new()
+                    .id(ID_NAVIGATION_VIEW_PAGER_CONTAINER)
+                    .name(ID_NAVIGATION_VIEW_PAGER_CONTAINER)
                     .padding(8)
                     .background("lynch")
                     .child(TextBlock::new().text("Page 1").build(ctx))
@@ -424,6 +749,8 @@ impl Template for NavigationView {
             )
             .child(
                 Container::new()
+                    .id(ID_NAVIGATION_VIEW_PAGER_CONTAINER2)
+                    .name(ID_NAVIGATION_VIEW_PAGER_CONTAINER2)
                     .padding(8)
                     .background("goldendream")
                     .child(
@@ -436,6 +763,8 @@ impl Template for NavigationView {
             )
             .child(
                 Container::new()
+                    .id(ID_NAVIGATION_VIEW_PAGER_CONTAINER3)
+                    .name(ID_NAVIGATION_VIEW_PAGER_CONTAINER3)
                     .padding(8)
                     .background("linkwater")
                     .child(
@@ -448,115 +777,152 @@ impl Template for NavigationView {
             )
             .build(ctx);
 
-        self.child(
-            Grid::new()
-                .margin(16)
-                .rows("32, *, 8, auto, 8, 32, *")
-                .child(TextBlock::new().text("Pager").style("header").build(ctx))
-                .child(pager)
-                .child(
-                    Button::new()
-                        .style("button_single_content")
-                        .icon(material_icons_font::MD_KEYBOARD_ARROW_LEFT)
-                        .h_align("start")
-                        .attach(Grid::row(3))
-                        .on_click(move |states, _| {
-                            states.send_message(PagerAction::Previous, pager);
-                            true
-                        })
-                        .build(ctx),
-                )
-                .child(
-                    Button::new()
-                        .style("button_single_content")
-                        .icon(material_icons_font::MD_KEYBOARD_ARROW_RIGHT)
-                        .h_align("end")
-                        .attach(Grid::row(3))
-                        .on_click(move |states, _| {
-                            states.send_message(PagerAction::Next, pager);
-                            true
-                        })
-                        .build(ctx),
-                )
-                .child(
-                    TextBlock::new()
-                        .text("MasterDetail")
-                        .attach(Grid::row(5))
-                        .style("header")
-                        .build(ctx),
-                )
-                .child(
-                    MasterDetail::new()
-                        .id(ID_NAVIGATION_MASTER_DETAIL)
-                        .responsive(true)
-                        .break_point(1000)
-                        .navigation_visibility(("md_navigation_visibility", id))
-                        .attach(Grid::row(6))
-                        .master_detail(
-                            Container::new()
-                                .padding(8)
-                                .background("lynch")
-                                .child(
-                                    Stack::new()
-                                        .orientation("vertical")
-                                        .h_align("center")
-                                        .v_align("center")
-                                        .child(TextBlock::new().text("Content inside the master pane")
-                                               .font_size(16)
-                                               .build(ctx))
-                                        .child(TextBlock::new().text("Resize the window: Pane brake is set to 800 pixel")
-                                               .font_size(14)
-                                               .build(ctx))
-                                        .build(ctx))
-                                .child(TextBlock::new().text("Master Pane").v_align("end").build(ctx))
-                                .child(
-                                    Button::new()
-                                        .style("button_primary_single_content")
-                                        .visibility(("md_navigation_visibility", id))
-                                        .h_align("start")
-                                        .text("show detail pane")
-                                        .on_click(move |ctx, _| {
-                                            ctx.send_message(MasterDetailAction::ShowDetail, id);
-                                            true
-                                        })
-                                        .build(ctx),
-                                )
-                                .build(ctx),
-                            Container::new()
-                                .padding(8)
-                                .background("goldendream")
-                                .child(TextBlock::new().text("Content inside the detail pane")
-                                       .h_align("center")
-                                       .v_align("center")
-                                       .foreground("black")
-                                       .font_size(14)
-                                       .build(ctx))
-                                .child(
-                                    TextBlock::new()
-                                        .text("Detail Pane")
-                                        .v_align("end")
-                                        .foreground("black")
-                                        .margin(8)
-                                        .build(ctx),
-                                )
-                                .child(
-                                    Button::new()
-                                        .text("back")
-                                        .style("button_single_content")
-                                        .visibility(("md_navigation_visibility", id))
-                                        .h_align("start")
-                                        .on_click(move |ctx, _| {
-                                            ctx.send_message(MasterDetailAction::ShowMaster, id);
-                                            true
-                                        })
-                                        .build(ctx),
-                                )
-                                .build(ctx),
-                        )
-                        .build(ctx),
-                )
-                .build(ctx),
-        )
+        self.id(ID_NAVIGATION_VIEW)
+            .name(ID_NAVIGATION_VIEW)
+            .child(
+                Grid::new()
+                    .id(ID_NAVIGATION_VIEW_GRID)
+                    .name(ID_NAVIGATION_VIEW_GRID)
+                    .margin(16)
+                    .rows("32, *, 8, auto, 8, 32, *")
+                    .child(TextBlock::new()
+                           .id(ID_NAVIGATION_VIEW_GRID_TEXT_BLOCK)
+                           .name(ID_NAVIGATION_VIEW_GRID_TEXT_BLOCK)
+                           .style("header")
+                           .text("Pager")
+                           .build(ctx))
+                    .child(pager)
+                    .child(
+                        Button::new()
+                            .id(ID_NAVIGATION_VIEW_GRID_BUTTON)
+                            .name(ID_NAVIGATION_VIEW_GRID_BUTTON)
+                            .style("button_single_content")
+                            .icon(material_icons_font::MD_KEYBOARD_ARROW_LEFT)
+                            .h_align("start")
+                            .attach(Grid::row(3))
+                            .on_click(move |states, _| {
+                                states.send_message(PagerAction::Previous, pager);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        Button::new()
+                            .id(ID_NAVIGATION_VIEW_GRID_BUTTON2)
+                            .name(ID_NAVIGATION_VIEW_GRID_BUTTON2)
+                            .style("button_single_content")
+                            .attach(Grid::row(3))
+                            .h_align("end")
+                            .icon(material_icons_font::MD_KEYBOARD_ARROW_RIGHT)
+                            .on_click(move |states, _| {
+                                states.send_message(PagerAction::Next, pager);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        TextBlock::new()
+                            .id(ID_NAVIGATION_VIEW_GRID_TEXT_BLOCK2)
+                            .text("MasterDetail")
+                            .attach(Grid::row(5))
+                            .style("header")
+                            .build(ctx),
+                    )
+                    .child(
+                        MasterDetail::new()
+                            .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL)
+                            .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL)
+                            .responsive(true)
+                            .break_point(1000)
+                            .navigation_visibility(("md_navigation_visibility", id))
+                            .attach(Grid::row(6))
+                            .master_detail(
+                                Container::new()
+                                    .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER)
+                                    .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER)
+                                    .padding(8)
+                                    .background("lynch")
+                                    .child(
+                                        Stack::new()
+                                            .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK)
+                                            .orientation("vertical")
+                                            .h_align("center")
+                                            .v_align("center")
+                                            .child(TextBlock::new().text("Content inside the master pane")
+                                                   .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK)
+                                                   .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK)
+                                                   .font_size(16)
+                                                   .build(ctx))
+                                            .child(TextBlock::new().text("Resize the window: Pane brake is set to 800 pixel")
+                                                   .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK2)
+                                                   .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_STACK_TEXT_BLOCK2)
+                                                   .font_size(14)
+                                                   .build(ctx))
+                                            .build(ctx))
+                                    .child(TextBlock::new()
+                                           .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_TEXT_BLOCK)
+                                           .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_TEXT_BLOCK)
+                                           .text("Master Pane")
+                                           .v_align("end")
+                                           .build(ctx))
+                                    .child(
+                                        Button::new()
+                                            .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_BUTTON)
+                                            .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER_BUTTON)
+                                            .style("button_primary_single_content")
+                                            .visibility(("md_navigation_visibility", id))
+                                            .h_align("start")
+                                            .text("show detail pane")
+                                            .on_click(move |ctx, _| {
+                                                ctx.send_message(MasterDetailAction::ShowDetail, id);
+                                                true
+                                            })
+                                            .build(ctx),
+                                    )
+                                    .build(ctx),
+                                Container::new()
+                                    .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2)
+                                    .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2)
+                                    .padding(8)
+                                    .background("goldendream")
+                                    .child(TextBlock::new()
+                                           .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_TEXT_BLOCK)
+                                           .font_size(14)
+                                           .foreground("black")
+                                           .h_align("center")
+                                           .text("Content inside the detail pane")
+                                           .v_align("center")
+                                           .build(ctx))
+                                    .child(
+                                        TextBlock::new()
+                                            .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_TEXT_BLOCK2)
+                                            .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_TEXT_BLOCK2)
+                                            .text("Detail Pane")
+                                            .v_align("end")
+                                            .foreground("black")
+                                            .margin(8)
+                                            .build(ctx),
+                                    )
+                                    .child(
+                                        Button::new()
+                                            .id(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_BUTTON)
+                                            .name(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL_CONTAINER2_BUTTON)
+                                            .text("back")
+                                            .style("button_single_content")
+                                            .visibility(("md_navigation_visibility", id))
+                                            .h_align("start")
+                                            .on_click(move |ctx, _| {
+                                                ctx.send_message(MasterDetailAction::ShowMaster, id);
+                                                true
+                                            })
+                                            .build(ctx),
+                                    )
+                                    .build(ctx),
+                            )
+                            .build(ctx),
+                    )
+                    .build(ctx),
+            )
     }
 }
 
@@ -581,135 +947,158 @@ impl Template for InteractiveView {
         ];
         let themes_count = themes.len();
 
-        self.count_text("0").themes(themes).child(
-            Grid::new()
-                .margin(8)
-                .rows("auto, 4, 32, 8, auto, 3, 32, 8, auto, 4, 32, 4, auto, 4, 32")
-                .columns("auto, 4, auto, 4, auto, *")
-                // theme selection
-                .child(
-                    TextBlock::new()
-                        .style("header")
-                        .attach(Grid::row(0))
-                        .attach(Grid::column(0))
-                        .style("small_text")
-                        .text("Select theme")
-                        .build(ctx),
-                )
-                .child(
-                    ComboBox::new()
-                        .attach(Grid::row(2))
-                        .attach(Grid::column(0))
-                        .count(themes_count)
-                        .items_builder(move |bc, index| {
-                            let text =
-                                InteractiveView::themes_ref(&bc.get_widget(id))[index].clone();
-                            TextBlock::new().v_align("center").text(text).build(bc)
-                        })
-                        .on_changed("selected_index", move |ctx, _| {
-                            ctx.send_message(InteractiveAction::ChangeTheme, id);
-                        })
-                        .selected_index(id)
-                        .build(ctx),
-                )
-                // Settings
-                .child(
-                    TextBlock::new()
-                        .h_align("start")
-                        .attach(Grid::row(4))
-                        .attach(Grid::column(0))
-                        .attach(Grid::column_span(5))
-                        .text("Settings")
-                        .style("header")
-                        .build(ctx),
-                )
-                .child(
-                    TextBox::new()
-                        .text(("settings_text", id))
-                        .attach(Grid::row(6))
-                        .attach(Grid::column(0))
-                        .water_mark("Insert text...")
-                        .build(ctx),
-                )
-                .child(
-                    Button::new()
-                        .text("load")
-                        .style("button_single_content")
-                        .attach(Grid::row(6))
-                        .attach(Grid::column(2))
-                        .on_click(move |ctx, _| {
-                            ctx.send_message(InteractiveAction::LoadSettings, id);
-                            true
-                        })
-                        .build(ctx),
-                )
-                .child(
-                    Button::new()
-                        .text("save")
-                        .style("button_single_content")
-                        .attach(Grid::row(6))
-                        .attach(Grid::column(4))
-                        .on_click(move |ctx, _| {
-                            ctx.send_message(InteractiveAction::SaveSettings, id);
-                            true
-                        })
-                        .build(ctx),
-                )
-                // Counter
-                .child(
-                    TextBlock::new()
-                        .h_align("start")
-                        .attach(Grid::row(8))
-                        .attach(Grid::column(0))
-                        .attach(Grid::column_span(5))
-                        .text("Counter")
-                        .style("header")
-                        .build(ctx),
-                )
-                .child(
-                    Button::new()
-                        .style("button_single_content")
-                        .attach(Grid::row(10))
-                        .attach(Grid::column(0))
-                        .icon(material_icons_font::MD_PLUS)
-                        .on_click(move |ctx, _| {
-                            ctx.send_message(InteractiveAction::Increment, id);
-                            true
-                        })
-                        .build(ctx),
-                )
-                .child(
-                    TextBlock::new()
-                        .style("body")
-                        .h_align("center")
-                        .v_align("center")
-                        .attach(Grid::row(12))
-                        .attach(Grid::column(0))
-                        .text(("count_text", id))
-                        .build(ctx),
-                )
-                .child(
-                    Button::new()
-                        .style("button_single_content")
-                        .attach(Grid::row(14))
-                        .attach(Grid::column(0))
-                        .icon(material_icons_font::MD_MINUS)
-                        .on_click(move |ctx, _| {
-                            ctx.send_message(InteractiveAction::Decrement, id);
-                            true
-                        })
-                        .build(ctx),
-                )
-                .build(ctx),
-        )
+        self.id(ID_INTERACTIVE_VIEW)
+            .name(ID_INTERACTIVE_VIEW)
+            .count_text("0")
+            .themes(themes)
+            .child(
+                Grid::new()
+                    .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK)
+                    .margin(8)
+                    .rows("auto, 4, 32, 8, auto, 3, 32, 8, auto, 4, 32, 4, auto, 4, 32")
+                    .columns("auto, 4, auto, 4, auto, *")
+                    // theme selection
+                    .child(
+                        TextBlock::new()
+                            .id(ID_INTERACTIVE_VIEW_TEXT_BLOCK)
+                            .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK)
+                            .style("header")
+                            .attach(Grid::row(0))
+                            .attach(Grid::column(0))
+                            .style("small_text")
+                            .text("Select theme")
+                            .build(ctx),
+                    )
+                    .child(
+                        ComboBox::new()
+                            .id(ID_INTERACTIVE_VIEW_COMBO_BOX)
+                            .name(ID_INTERACTIVE_VIEW_COMBO_BOX)
+                            .attach(Grid::row(2))
+                            .attach(Grid::column(0))
+                            .count(themes_count)
+                            .items_builder(move |bc, index| {
+                                let text =
+                                    InteractiveView::themes_ref(&bc.get_widget(id))[index].clone();
+                                TextBlock::new().v_align("center").text(text).build(bc)
+                            })
+                            .on_changed("selected_index", move |ctx, _| {
+                                ctx.send_message(InteractiveAction::ChangeTheme, id);
+                            })
+                            .selected_index(id)
+                            .build(ctx),
+                    )
+                    // Settings
+                    .child(
+                        TextBlock::new()
+                            .id(ID_INTERACTIVE_VIEW_TEXT_BLOCK2)
+                            .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK2)
+                            .h_align("start")
+                            .attach(Grid::row(4))
+                            .attach(Grid::column(0))
+                            .attach(Grid::column_span(5))
+                            .text("Settings")
+                            .style("header")
+                            .build(ctx),
+                    )
+                    .child(
+                        TextBox::new()
+                            .id(ID_INTERACTIVE_VIEW_TEXT_BLOCK3)
+                            .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK3)
+                            .text(("settings_text", id))
+                            .attach(Grid::row(6))
+                            .attach(Grid::column(0))
+                            .water_mark("Insert text...")
+                            .build(ctx),
+                    )
+                    .child(
+                        Button::new()
+                            .id(ID_INTERACTIVE_VIEW_BUTTON)
+                            .name(ID_INTERACTIVE_VIEW_BUTTON)
+                            .style("button_single_content")
+                            .attach(Grid::row(6))
+                            .attach(Grid::column(2))
+                            .text("load")
+                            .on_click(move |ctx, _| {
+                                ctx.send_message(InteractiveAction::LoadSettings, id);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        Button::new()
+                            .id(ID_INTERACTIVE_VIEW_BUTTON2)
+                            .name(ID_INTERACTIVE_VIEW_BUTTON2)
+                            .style("button_single_content")
+                            .attach(Grid::row(6))
+                            .attach(Grid::column(4))
+                            .text("save")
+                            .on_click(move |ctx, _| {
+                                ctx.send_message(InteractiveAction::SaveSettings, id);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    // Counter
+                    .child(
+                        TextBlock::new()
+                            .id(ID_INTERACTIVE_VIEW_TEXT_BLOCK4)
+                            .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK4)
+                            .h_align("start")
+                            .attach(Grid::row(8))
+                            .attach(Grid::column(0))
+                            .attach(Grid::column_span(5))
+                            .text("Counter")
+                            .style("header")
+                            .build(ctx),
+                    )
+                    .child(
+                        Button::new()
+                            .id(ID_INTERACTIVE_VIEW_BUTTON3)
+                            .name(ID_INTERACTIVE_VIEW_BUTTON3)
+                            .style("button_single_content")
+                            .attach(Grid::row(10))
+                            .attach(Grid::column(0))
+                            .icon(material_icons_font::MD_PLUS)
+                            .on_click(move |ctx, _| {
+                                ctx.send_message(InteractiveAction::Increment, id);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    .child(
+                        TextBlock::new()
+                            .id(ID_INTERACTIVE_VIEW_TEXT_BLOCK5)
+                            .name(ID_INTERACTIVE_VIEW_TEXT_BLOCK5)
+                            .style("body")
+                            .h_align("center")
+                            .v_align("center")
+                            .attach(Grid::row(12))
+                            .attach(Grid::column(0))
+                            .text(("count_text", id))
+                            .build(ctx),
+                    )
+                    .child(
+                        Button::new()
+                            .id(ID_INTERACTIVE_VIEW_BUTTON4)
+                            .name(ID_INTERACTIVE_VIEW_BUTTON4)
+                            .style("button_single_content")
+                            .attach(Grid::row(14))
+                            .attach(Grid::column(0))
+                            .icon(material_icons_font::MD_MINUS)
+                            .on_click(move |ctx, _| {
+                                ctx.send_message(InteractiveAction::Decrement, id);
+                                true
+                            })
+                            .build(ctx),
+                    )
+                    .build(ctx),
+            )
     }
 }
 
 // [END] views
 
 // [START] states
-
-static ID_NAVIGATION_MASTER_DETAIL: &str = "id_navigation_master_detail";
 
 #[derive(Debug, Default, AsAny)]
 struct NavigationState {
@@ -718,7 +1107,7 @@ struct NavigationState {
 
 impl State for NavigationState {
     fn init(&mut self, _registry: &mut Registry, ctx: &mut Context) {
-        self.master_detail = ctx.child(ID_NAVIGATION_MASTER_DETAIL).entity();
+        self.master_detail = ctx.child(ID_NAVIGATION_VIEW_GRID_MASTER_DETAIL).entity();
     }
 
     fn messages(

--- a/orbtk_core/src/macros.rs
+++ b/orbtk_core/src/macros.rs
@@ -7,39 +7,39 @@ pub use dces::prelude::*;
 #[macro_export]
 macro_rules! into_property_source {
     ($type:ty $(: $( $ex_type:ty ),*)* ) => {
-        impl IntoPropertySource<$type> for $type {
-            fn into_source(self) -> PropertySource<$type> {
-                PropertySource::Value(self)
-            }
-        }
+	impl IntoPropertySource<$type> for $type {
+	    fn into_source(self) -> PropertySource<$type> {
+		PropertySource::Value(self)
+	    }
+	}
 
-        impl IntoPropertySource<$type> for Entity {
-            fn into_source(self) -> PropertySource<$type> {
-                PropertySource::Source(self)
-            }
-        }
+	impl IntoPropertySource<$type> for Entity {
+	    fn into_source(self) -> PropertySource<$type> {
+		PropertySource::Source(self)
+	    }
+	}
 
-        impl IntoPropertySource<$type> for (String, Entity) {
-            fn into_source(self) -> PropertySource<$type> {
-                PropertySource::KeySource(self.0, self.1)
-            }
-        }
+	impl IntoPropertySource<$type> for (String, Entity) {
+	    fn into_source(self) -> PropertySource<$type> {
+		PropertySource::KeySource(self.0, self.1)
+	    }
+	}
 
-        impl IntoPropertySource<$type> for (&str, Entity) {
-            fn into_source(self) -> PropertySource<$type> {
-                PropertySource::KeySource(self.0.to_string(), self.1)
-            }
-        }
+	impl IntoPropertySource<$type> for (&str, Entity) {
+	    fn into_source(self) -> PropertySource<$type> {
+		PropertySource::KeySource(self.0.to_string(), self.1)
+	    }
+	}
 
-         $(
-            $(
-                impl IntoPropertySource<$type> for $ex_type {
-                    fn into_source(self) -> PropertySource<$type> {
-                        PropertySource::Value(self.into())
-                    }
-                }
-            )*
-        )*
+	 $(
+	    $(
+		impl IntoPropertySource<$type> for $ex_type {
+		    fn into_source(self) -> PropertySource<$type> {
+			PropertySource::Value(self.into())
+		    }
+		}
+	    )*
+	)*
     };
 }
 
@@ -76,486 +76,487 @@ macro_rules! into_property_source {
 #[macro_export]
 macro_rules! widget {
     ( $(#[$widget_doc:meta])* $widget:ident $(<$state:ident>)* $(: $( $handler:ident ),*)*
-            $( { $($(#[$prop_doc:meta])* $property:ident: $property_type:tt ),*
-                $( attached_properties: { $($(#[$att_prop_doc:meta])* $att_property:ident: $att_property_type:tt ),* } )*
-             } )* ) => {
-        $(#[$widget_doc])*
-        #[derive(Default, WidgetCtx)]
-        #[allow(dead_code)]
-        pub struct $widget {
-            attached_properties: HashMap<String, ComponentBox>,
-            shared_attached_properties: HashMap<(String, String), SharedComponentBox>,
-            event_handlers: Vec<Rc<dyn EventHandler>>,
-            #[property(Rectangle)]
-            bounds: Rectangle,
-            #[property(Point)]
-            position: Point,
-            #[property(Constraint)]
-            constraint: Constraint,
-            min_width: Option<f64>,
-            min_height: Option<f64>,
-            max_width: Option<f64>,
-            max_height: Option<f64>,
-            width: Option<f64>,
-            height: Option<f64>,
-            name: Option<String>,
-            style: Option<String>,
-            id: Option<String>,
-            #[property(Alignment)]
-            h_align: Alignment,
-            #[property(Alignment)]
-            v_align: Alignment,
-            #[property(Thickness)]
-            margin: Thickness,
-            #[property(bool)]
-            enabled: bool,
-            #[property(bool)]
-            clip: bool,
-            #[property(f32)]
-            opacity: f32,
-            #[property(Visibility)]
-            visibility: Visibility,
-            #[property(Selector)]
-            selector: Selector,
-            #[property(Filter)]
-            on_changed_filter: Filter,
-            changed_handler: ChangedEventHandler,
-            _empty: Option<RefCell<i32>>,
-             $(
-                $(
-                    #[property($property_type)]
-                    $property: Option<PropertySource<$property_type>>,
-                )*
-             )*
-            children: Vec<Entity>,
-            $(
-                state: Box<$state>
-            )*
-        }
+	    $( { $($(#[$prop_doc:meta])* $property:ident: $property_type:tt ),*
+		$( attached_properties: { $($(#[$att_prop_doc:meta])* $att_property:ident: $att_property_type:tt ),* } )*
+	     } )* ) => {
+	$(#[$widget_doc])*
+	#[derive(Default, WidgetCtx)]
+	#[allow(dead_code)]
+	pub struct $widget {
+	    attached_properties: HashMap<String, ComponentBox>,
+	    #[property(Rectangle)]
+	    bounds: Rectangle,
+	    changed_handler: ChangedEventHandler,
+	    #[property(Constraint)]
+	    constraint: Constraint,
+	    #[property(bool)]
+	    clip: bool,
+	    #[property(bool)]
+	    enabled: bool,
+	    event_handlers: Vec<Rc<dyn EventHandler>>,
+	    height: Option<f64>,
+	    #[property(Alignment)]
+	    h_align: Alignment,
+	    #[property(Thickness)]
+	    margin: Thickness,
+	    max_height: Option<f64>,
+	    max_width: Option<f64>,
+	    min_height: Option<f64>,
+	    min_width: Option<f64>,
+	    name: Option<String>,
+	    #[property(Filter)]
+	    on_changed_filter: Filter,
+	    #[property(f32)]
+	    opacity: f32,
+	    #[property(Point)]
+	    position: Point,
+	    #[property(Selector)]
+	    selector: Selector,
+	    shared_attached_properties: HashMap<(String, String), SharedComponentBox>,
+	    style: Option<String>,
+	    id: Option<String>,
+	    #[property(Visibility)]
+	    visibility: Visibility,
+	    #[property(Alignment)]
+	    v_align: Alignment,
+	    width: Option<f64>,
+	    _empty: Option<RefCell<i32>>,
+	     $(
+		$(
+		    #[property($property_type)]
+		    $property: Option<PropertySource<$property_type>>,
+		)*
+	     )*
+	    children: Vec<Entity>,
+	    $(
+		state: Box<$state>
+	    )*
+	}
 
-        impl $widget {
-            // internal helper
-            fn set_property<P: Component + Debug>(mut self, key: &str, property: impl IntoPropertySource<P>) -> Self {
-                match property.into_source() {
-                    PropertySource::Value(value) => {
-                        self.attached_properties.insert(key.to_string(), ComponentBox::new(value));
-                    },
-                    PropertySource::Source(source) => {
-                        self.shared_attached_properties.insert((key.to_string(), key.to_string()), SharedComponentBox::new(TypeId::of::<P>(), source));
-                    }
-                    PropertySource::KeySource(source_key, source) => {
-                        self.shared_attached_properties.insert((key.to_string(), source_key), SharedComponentBox::new(TypeId::of::<P>(), source));
-                    }
-                }
-                self
-            }
+	impl $widget {
+	    /// Sets or shares the clip property.
+	    pub fn clip(self, clip: impl IntoPropertySource<bool>) -> Self {
+		self.set_property("clip", clip)
+	    }
 
-            /// Sets the id selector.
-            pub fn id(mut self, id: impl Into<String>) -> Self {
-                if !self.id.is_none() {
-                    return self;
-                }
-                self.id = Some(id.into());
-                self
-            }
+	    /// Sets or shares the constraint property.
+	    pub fn constraint(self, constraint: impl IntoPropertySource<Constraint>) -> Self {
+		self.set_property("constraint", constraint)
+	    }
 
-            /// Sets the style selector (replaces the old selector property).
-            pub fn style(mut self, style: impl Into<String>) -> Self {
-                if !self.style.is_none() {
-                    return self;
-                }
+	    /// Sets or shares the enabled property.
+	    pub fn enabled(self, enabled: impl IntoPropertySource<bool>) -> Self {
+		self.set_property("enabled", enabled)
+	    }
 
-                self.style = Some(style.into());
-                self
-            }
+	    /// Inserts a new height.
+	    pub fn height(mut self, height: impl Into<f64>) -> Self {
+		if !self.height.is_none() {
+		    return self;
+		}
+		self.height = Some(height.into());
+		self
+	    }
 
-            /// Sets or shares the position of the widget. (Be careful the position could be adjusted by layouts).
-            pub fn position(self, position: impl IntoPropertySource<Point>) -> Self {
-                self.set_property("position", position)
-            }
+	    /// Sets or shares the horizontal alignment property.
+	    #[inline(always)]
+	    #[deprecated = "Use h_align instead"]
+	    pub fn horizontal_alignment(self, horizontal_alignment: impl IntoPropertySource<Alignment>) -> Self {
+		self.h_align(horizontal_alignment)
+	    }
 
-            /// Sets or shares the constraint property.
-            pub fn constraint(self, constraint: impl IntoPropertySource<Constraint>) -> Self {
-                self.set_property("constraint", constraint)
-            }
+	    /// Sets or shares the horizontal alignment property.
+	     #[inline(always)]
+	     pub fn h_align(self, h_align: impl IntoPropertySource<Alignment>) -> Self {
+		 self.set_property("h_align", h_align)
+	     }
 
-            /// Sets or shares the vertical alignment property.
-            #[inline(always)]
-            pub fn v_align(self, v_align: impl IntoPropertySource<Alignment>) -> Self {
-                self.set_property("v_align", v_align)
-            }
+	    /// Sets the id selector.
+	    pub fn id(mut self, id: impl Into<String>) -> Self {
+		if !self.id.is_none() {
+		    return self;
+		}
+		self.id = Some(id.into());
+		self
+	    }
 
-             /// Sets or shares the horizontal alignment property.
-             #[inline(always)]
-             pub fn h_align(self, h_align: impl IntoPropertySource<Alignment>) -> Self {
-                 self.set_property("h_align", h_align)
-             }
+	    /// Sets or shares the margin property.
+	    pub fn margin(self, margin: impl IntoPropertySource<Thickness>) -> Self {
+		self.set_property("margin", margin)
+	    }
 
-            /// Sets or shares the vertical alignment property.
-            #[inline(always)]
-            #[deprecated = "Use v_align instead"]
-            pub fn vertical_alignment(self, vertical_alignment: impl IntoPropertySource<Alignment>) -> Self {
-                self.v_align(vertical_alignment)
-            }
+	    /// Inserts a new max_height.
+	    pub fn max_height(mut self, max_height: impl Into<f64>) -> Self {
+		if !self.max_height.is_none() {
+		    return self;
+		}
+		self.max_height = Some(max_height.into());
+		self
+	    }
 
-            /// Sets or shares the horizontal alignment property.
-            #[inline(always)]
-            #[deprecated = "Use h_align instead"]
-            pub fn horizontal_alignment(self, horizontal_alignment: impl IntoPropertySource<Alignment>) -> Self {
-                self.h_align(horizontal_alignment)
-            }
+	    /// Inserts a new min_size.
+	    pub fn max_size(mut self, max_width: impl Into<f64>, max_height: impl Into<f64>) -> Self {
+		if self.max_width.is_none() {
+		    self.max_width = Some(max_width.into());
+		}
+		if self.max_height.is_none() {
+		    self.max_height = Some(max_height.into());
+		}
+		self
+	    }
 
-            /// Sets or shares the visibility property.
-            pub fn visibility(self, visibility: impl IntoPropertySource<Visibility>) -> Self {
-                self.set_property("visibility", visibility)
-            }
+	    /// Inserts a new max_width.
+	    pub fn max_width(mut self, max_width: impl Into<f64>) -> Self {
+		if !self.max_width.is_none() {
+		    return self;
+		}
+		self.max_width = Some(max_width.into());
+		self
+	    }
 
-            /// Sets or shares the margin property.
-            pub fn margin(self, margin: impl IntoPropertySource<Thickness>) -> Self {
-                self.set_property("margin", margin)
-            }
+	    /// Inserts a new min_height.
+	    pub fn min_height(mut self, min_height: impl Into<f64>) -> Self {
+		if !self.min_height.is_none() {
+		    return self;
+		}
+		self.min_height = Some(min_height.into());
+		self
+	    }
 
-            /// Sets or shares the enabled property.
-            pub fn enabled(self, enabled: impl IntoPropertySource<bool>) -> Self {
-                self.set_property("enabled", enabled)
-            }
+	    /// Inserts a new min_size.
+	    pub fn min_size(mut self, min_width: impl Into<f64>, min_height: impl Into<f64>) -> Self {
+		if self.min_width.is_none() {
+		    self.min_width = Some(min_width.into());
+		}
+		if self.min_height.is_none() {
+		    self.min_height = Some(min_height.into());
+		}
+		self
+	    }
 
-            /// Sets or shares the clip property.
-            pub fn clip(self, clip: impl IntoPropertySource<bool>) -> Self {
-                self.set_property("clip", clip)
-            }
+	    /// Inserts a new min_width.
+	    pub fn min_width(mut self, min_width: impl Into<f64>) -> Self {
+		if !self.min_width.is_none() {
+		    return self;
+		}
+		self.min_width = Some(min_width.into());
+		self
+	    }
 
-            /// Sets or shares the opacity property.
-            pub fn opacity(self, opacity: impl IntoPropertySource<f32>) -> Self {
-                self.set_property("opacity", opacity)
-            }
+	    /// Sets the debug name of the widget.
+	    pub fn name<P: Into<String>>(mut self, name: P) -> Self {
+		self.name = Some(name.into());
+		self
+	    }
 
-            /// Inserts a new width.
-            pub fn width(mut self, width: impl Into<f64>) -> Self {
-                if !self.width.is_none() {
-                    return self;
-                }
-                self.width = Some(width.into());
-                self
-            }
+	    /// Sets or shares the opacity property.
+	    pub fn opacity(self, opacity: impl IntoPropertySource<f32>) -> Self {
+		self.set_property("opacity", opacity)
+	    }
 
-            /// Inserts a new height.
-            pub fn height(mut self, height: impl Into<f64>) -> Self {
-                if !self.height.is_none() {
-                    return self;
-                }
-                self.height = Some(height.into());
-                self
-            }
+	    /// Checks if the type of the given widget is the same as the associated type of struct otherwise this method will panic.
+	    pub fn panics_on_wrong_type(widget: &WidgetContainer) {
+		if *widget.get::<TypeId>("type_id") != TypeId::of::<$widget>() {
+		    let struct_type_name = std::any::type_name::<$widget>().to_string();
+		    let widget_type_name = widget.clone::<String>("type_name");
 
-            /// Inserts a new size.
-            pub fn size(mut self, width: impl Into<f64>, height: impl Into<f64>) -> Self {
-                if self.width.is_none() {
-                    self.width = Some(width.into());
-                }
-                if self.height.is_none() {
-                    self.height = Some(height.into());
-                }
-                self
-            }
+		    panic!("Wrong widget type: expected {}, found {}", struct_type_name, widget_type_name);
+		}
+	    }
 
-            /// Inserts a new min_width.
-            pub fn min_width(mut self, min_width: impl Into<f64>) -> Self {
-                if !self.min_width.is_none() {
-                    return self;
-                }
-                self.min_width = Some(min_width.into());
-                self
-            }
+	    /// Sets or shares the position of the widget. (Be careful the position could be adjusted by layouts).
+	    pub fn position(self, position: impl IntoPropertySource<Point>) -> Self {
+		self.set_property("position", position)
+	    }
 
-            /// Inserts a new min_height.
-            pub fn min_height(mut self, min_height: impl Into<f64>) -> Self {
-                if !self.min_height.is_none() {
-                    return self;
-                }
-                self.min_height = Some(min_height.into());
-                self
-            }
+	    // internal helper
+	    fn set_property<P: Component + Debug>(mut self, key: &str, property: impl IntoPropertySource<P>) -> Self {
+		match property.into_source() {
+		    PropertySource::Value(value) => {
+			self.attached_properties.insert(key.to_string(), ComponentBox::new(value));
+		    },
+		    PropertySource::Source(source) => {
+			self.shared_attached_properties.insert((key.to_string(), key.to_string()), SharedComponentBox::new(TypeId::of::<P>(), source));
+		    }
+		    PropertySource::KeySource(source_key, source) => {
+			self.shared_attached_properties.insert((key.to_string(), source_key), SharedComponentBox::new(TypeId::of::<P>(), source));
+		    }
+		}
+		self
+	    }
 
-            /// Inserts a new min_size.
-            pub fn min_size(mut self, min_width: impl Into<f64>, min_height: impl Into<f64>) -> Self {
-                if self.min_width.is_none() {
-                    self.min_width = Some(min_width.into());
-                }
-                if self.min_height.is_none() {
-                    self.min_height = Some(min_height.into());
-                }
-                self
-            }
+	    /// Inserts a new size.
+	    pub fn size(mut self, width: impl Into<f64>, height: impl Into<f64>) -> Self {
+		if self.width.is_none() {
+		    self.width = Some(width.into());
+		}
+		if self.height.is_none() {
+		    self.height = Some(height.into());
+		}
+		self
+	    }
 
-            /// Inserts a new max_width.
-            pub fn max_width(mut self, max_width: impl Into<f64>) -> Self {
-                if !self.max_width.is_none() {
-                    return self;
-                }
-                self.max_width = Some(max_width.into());
-                self
-            }
+	    /// Sets the style selector (replaces the old selector property).
+	    pub fn style(mut self, style: impl Into<String>) -> Self {
+		if !self.style.is_none() {
+		    return self;
+		}
 
-            /// Inserts a new max_height.
-            pub fn max_height(mut self, max_height: impl Into<f64>) -> Self {
-                if !self.max_height.is_none() {
-                    return self;
-                }
-                self.max_height = Some(max_height.into());
-                self
-            }
+		self.style = Some(style.into());
+		self
+	    }
 
-            /// Inserts a new min_size.
-            pub fn max_size(mut self, max_width: impl Into<f64>, max_height: impl Into<f64>) -> Self {
-                if self.max_width.is_none() {
-                    self.max_width = Some(max_width.into());
-                }
-                if self.max_height.is_none() {
-                    self.max_height = Some(max_height.into());
-                }
-                self
-            }
+	    /// Sets or shares the vertical alignment property.
+	    #[inline(always)]
+	    #[deprecated = "Use v_align instead"]
+	    pub fn vertical_alignment(self, vertical_alignment: impl IntoPropertySource<Alignment>) -> Self {
+		self.v_align(vertical_alignment)
+	    }
 
-            /// Sets the debug name of the widget.
-            pub fn name<P: Into<String>>(mut self, name: P) -> Self {
-                self.name = Some(name.into());
-                self
-            }
+	    /// Sets or shares the visibility property.
+	    pub fn visibility(self, visibility: impl IntoPropertySource<Visibility>) -> Self {
+		self.set_property("visibility", visibility)
+	    }
 
-            /// Checks if the type of the given widget is the same as the associated type of struct otherwise this method will panic.
-            pub fn panics_on_wrong_type(widget: &WidgetContainer) {
-                if *widget.get::<TypeId>("type_id") != TypeId::of::<$widget>() {
-                    let struct_type_name = std::any::type_name::<$widget>().to_string();
-                    let widget_type_name = widget.clone::<String>("type_name");
+	    /// Sets or shares the vertical alignment property.
+	    #[inline(always)]
+	    pub fn v_align(self, v_align: impl IntoPropertySource<Alignment>) -> Self {
+		self.set_property("v_align", v_align)
+	    }
 
-                    panic!("Wrong widget type: expected {}, found {}", struct_type_name, widget_type_name);
-                }
-            }
+	    /// Inserts a new width.
+	    pub fn width(mut self, width: impl Into<f64>) -> Self {
+		if !self.width.is_none() {
+		    return self;
+		}
+		self.width = Some(width.into());
+		self
+	    }
 
-            $(
-                /// Gets a reference of the state.
-                fn state(&self) -> &Box<$state> {
-                    &self.state
-                }
+	    $(
+		/// Gets a reference of the state.
+		fn state(&self) -> &Box<$state> {
+		    &self.state
+		}
 
-                /// Gets a mutable reference of the state.
-                fn state_mut(&mut self) -> &mut Box<$state> {
-                    &mut self.state
-                }
-            )*
+		/// Gets a mutable reference of the state.
+		fn state_mut(&mut self) -> &mut Box<$state> {
+		    &mut self.state
+		}
+	    )*
 
-            // create properties of macros
-            $(
-                $(
-                    $(#[$prop_doc])*
-                    pub fn $property<P: IntoPropertySource<$property_type>>(mut self, $property: P) -> Self {
-                        if !self.$property.is_none() {
-                            return self;
-                        }
+	    // create properties of macros
+	    $(
+		$(
+		    $(#[$prop_doc])*
+		    pub fn $property<P: IntoPropertySource<$property_type>>(mut self, $property: P) -> Self {
+			if !self.$property.is_none() {
+			    return self;
+			}
 
-                        self.$property = Some($property.into_source());
-                        self
-                    }
-                )*
-            )*
+			self.$property = Some($property.into_source());
+			self
+		    }
+		)*
+	    )*
 
-            $(
-                $(
-                    $(
-                        $(#[$att_prop_doc])*
-                        pub fn $att_property(property: impl IntoPropertySource<$att_property_type>) -> AttachedProperty<$att_property_type> {
-                            AttachedProperty::new(stringify!($att_property), property)
-                        }
-                    )*
-                )*
-            )*
-        }
+	    $(
+		$(
+		    $(
+			$(#[$att_prop_doc])*
+			pub fn $att_property(property: impl IntoPropertySource<$att_property_type>) -> AttachedProperty<$att_property_type> {
+			    AttachedProperty::new(stringify!($att_property), property)
+			}
+		    )*
+		)*
+	    )*
+	}
 
-        // event handlers
-        $(
-            $(
-                impl $handler for $widget {}
-            )*
-        )*
+	// event handlers
+	$(
+	    $(
+		impl $handler for $widget {}
+	    )*
+	)*
 
-        impl ChangedHandler for $widget {}
+	impl ChangedHandler for $widget {}
 
-        impl Widget for $widget {
-            /// Creates a new widget.
-            #[inline]
-            fn new() -> Self {
-                $widget {
-                    event_handlers: vec![],
-                    enabled: true,
-                    opacity: 1.,
-                    clip: false,
-                    $(
-                        $(
-                            $property: None,
-                        )*
-                    )*
-                    children: vec![],
-                    ..Default::default()
-                }
-            }
+	impl Widget for $widget {
+	    fn attach<P: Component + Debug>(mut self, property: AttachedProperty<P>) -> Self {
+		match property.property_source {
+		    PropertySource::Value(value) => {
+			self.attached_properties.insert(property.key, ComponentBox::new(value));
+		    }
+		    PropertySource::Source(source) => {
+			self.shared_attached_properties.insert((property.key.clone(), property.key), SharedComponentBox::new(TypeId::of::<P>(), source));
+		    }
+		    PropertySource::KeySource(source_key, source) => {
+			self.shared_attached_properties.insert((property.key, source_key), SharedComponentBox::new(TypeId::of::<P>(), source));
+		    }
+		}
+		self
+	    }
 
-            fn attach<P: Component + Debug>(mut self, property: AttachedProperty<P>) -> Self {
-                match property.property_source {
-                    PropertySource::Value(value) => {
-                        self.attached_properties.insert(property.key, ComponentBox::new(value));
-                    }
-                    PropertySource::Source(source) => {
-                        self.shared_attached_properties.insert((property.key.clone(), property.key), SharedComponentBox::new(TypeId::of::<P>(), source));
-                    }
-                    PropertySource::KeySource(source_key, source) => {
-                        self.shared_attached_properties.insert((property.key, source_key), SharedComponentBox::new(TypeId::of::<P>(), source));
-                    }
-                }
-                self
-            }
 
-            fn insert_handler(mut self, handler: impl Into<Rc<dyn EventHandler>>) -> Self {
-                self.event_handlers.push(handler.into());
-                self
-            }
+	    fn build(self, ctx: &mut BuildContext) -> Entity {
+		let entity = ctx.create_entity();
 
-            fn insert_changed_handler<H: Fn(&mut StatesContext, Entity) + 'static>(mut self, key: impl Into<String>, handler: Rc<H>) -> Self {
-                let key = key.into();
-                if let Filter::List(filter) = &mut self.on_changed_filter {
-                    filter.push(key.clone());
-                } else {
-                    self.on_changed_filter = Filter::List(vec![key.clone()]);
-                }
-                self.changed_handler.handlers.insert(key, handler);
-                self
-            }
+		let this = self.template(entity, ctx);
 
-            fn child(mut self, child: Entity) -> Self {
-                self.children.push(child);
-                self
-            }
+		ctx.register_render_object(entity, this.render_object());
+		ctx.register_layout(entity, this.layout());
 
-            fn build(self, ctx: &mut BuildContext) -> Entity {
-                let entity = ctx.create_entity();
+		$(
+		    // workaround
+		    let _ = TypeId::of::<$state>();
+		    ctx.register_state(entity, this.state);
+		)*
 
-                let this = self.template(entity, ctx);
+		// register a set of properties as components
+		ctx.register_property("bounds", entity, this.bounds);
+		ctx.register_property("clip", entity, this.clip);
+		ctx.register_property("dirty", entity, false);
+		ctx.register_property("enabled", entity, this.enabled);
+		ctx.register_property("h_align", entity, this.h_align);
+		ctx.register_property("margin", entity, this.margin);
+		ctx.register_property("on_changed_filter", entity, this.on_changed_filter);
+		ctx.register_property("opacity", entity, this.opacity);
+		ctx.register_property("position", entity, this.position);
+		ctx.register_property("type_id", entity, TypeId::of::<$widget>());
+		ctx.register_property("type_name", entity, std::any::type_name::<$widget>().to_string());
+		ctx.register_property("visibility", entity, this.visibility);
+		ctx.register_property("v_align", entity, this.v_align);
 
-                ctx.register_render_object(entity, this.render_object());
-                ctx.register_layout(entity, this.layout());
+		let mut constraint = this.constraint;
 
-                $(
-                    // workaround
-                    let _ = TypeId::of::<$state>();
-                    ctx.register_state(entity, this.state);
-                )*
+		if let Some(width) = this.width {
+		    constraint.set_width(width);
+		}
+		if let Some(height) = this.height {
+		    constraint.set_height(height);
+		}
+		if let Some(min_width) = this.min_width {
+		    constraint.set_min_width(min_width);
+		}
+		if let Some(min_height) = this.min_height {
+		    constraint.set_min_height(min_height);
+		}
+		if let Some(max_width) = this.max_width {
+		    constraint.set_max_width(max_width);
+		}
+		if let Some(max_height) = this.max_height {
+		    constraint.set_max_height(max_height);
+		}
+		ctx.register_property("constraint", entity, constraint);
 
-                // register a set of properties as components
-                ctx.register_property("bounds", entity, this.bounds);
-                ctx.register_property("position", entity, this.position);
-                ctx.register_property("v_align", entity, this.v_align);
-                ctx.register_property("h_align", entity, this.h_align);
-                ctx.register_property("on_changed_filter", entity, this.on_changed_filter);
-                ctx.register_property("visibility", entity, this.visibility);
-                ctx.register_property("margin", entity, this.margin);
-                ctx.register_property("enabled", entity, this.enabled);
-                ctx.register_property("clip", entity, this.clip);
-                ctx.register_property("opacity", entity, this.opacity);
-                ctx.register_property("type_id", entity, TypeId::of::<$widget>());
-                ctx.register_property("type_name", entity, std::any::type_name::<$widget>().to_string());
-                ctx.register_property("dirty", entity, false);
+		// register attached properties
+		for (key, property) in this.attached_properties {
+		    ctx.register_property_box(key.as_str(), entity, property);
+		}
 
-                let mut constraint = this.constraint;
+		for (key, property) in this.shared_attached_properties {
+		    ctx.register_property_shared_box_by_source_key(key.0.as_str(), key.1.as_str(), entity, property);
+		}
 
-                if let Some(width) = this.width {
-                    constraint.set_width(width);
-                }
-                if let Some(height) = this.height {
-                    constraint.set_height(height);
-                }
-                if let Some(min_width) = this.min_width {
-                    constraint.set_min_width(min_width);
-                }
-                if let Some(min_height) = this.min_height {
-                    constraint.set_min_height(min_height);
-                }
-                if let Some(max_width) = this.max_width {
-                    constraint.set_max_width(max_width);
-                }
-                if let Some(max_height) = this.max_height {
-                    constraint.set_max_height(max_height);
-                }
-                ctx.register_property("constraint", entity, constraint);
+		// register properties
+		$(
+		    $(
+			if let Some($property) = this.$property {
+			    match $property {
+				PropertySource::Value(value) => {
+				    ctx.register_property(stringify!($property), entity, value);
+				}
+				PropertySource::Source(source) => {
+				    ctx.register_shared_property::<$property_type>(stringify!($property), entity, source);
+				}
+				PropertySource::KeySource(source_key, source) => {
+				    ctx.register_shared_property_by_source_key::<$property_type>(stringify!($property), source_key.as_str(), entity, source);
+				}
+			    }
+			}
+			else {
+			    ctx.register_property(stringify!($property), entity, $property_type::default());
+			}
+		    )*
+		)*
 
-                // register attached properties
-                for (key, property) in this.attached_properties {
-                    ctx.register_property_box(key.as_str(), entity, property);
-                }
+		if let Some(id) = this.id {
+		    ctx.register_property("id", entity, id);
+		}
 
-                for (key, property) in this.shared_attached_properties {
-                    ctx.register_property_shared_box_by_source_key(key.0.as_str(), key.1.as_str(), entity, property);
-                }
+		let mut selector = if let Some(style) = this.style {
+		    Selector::new(style)
+		} else {
+		    this.selector
+		};
 
-                // register properties
-                $(
-                    $(
-                        if let Some($property) = this.$property {
-                            match $property {
-                                PropertySource::Value(value) => {
-                                    ctx.register_property(stringify!($property), entity, value);
-                                }
-                                PropertySource::Source(source) => {
-                                    ctx.register_shared_property::<$property_type>(stringify!($property), entity, source);
-                                }
-                                PropertySource::KeySource(source_key, source) => {
-                                    ctx.register_shared_property_by_source_key::<$property_type>(stringify!($property), source_key.as_str(), entity, source);
-                                }
-                            }
-                        }
-                        else {
-                            ctx.register_property(stringify!($property), entity, $property_type::default());
-                        }
-                    )*
-                )*
+		// initial set disabled
+		if ctx.get_widget(entity).has::<bool>("enabled") && !*ctx.get_widget(entity).get::<bool>("enabled") {
+		    selector.push_state("disabled");
+		}
 
-                if let Some(id) = this.id {
-                    ctx.register_property("id", entity, id);
-                }
+		ctx.register_property("selector", entity, selector);
 
-                let mut selector = if let Some(style) = this.style {
-                    Selector::new(style)
-                } else {
-                    this.selector
-                };
+		ctx.update_theme_by_state(entity);
 
-                // initial set disabled
-                if ctx.get_widget(entity).has::<bool>("enabled") && !*ctx.get_widget(entity).get::<bool>("enabled") {
-                    selector.push_state("disabled");
-                }
+		// register event handlers
+		for handler in this.event_handlers {
+		    ctx.register_handler(entity, handler);
+		}
 
-                ctx.register_property("selector", entity, selector);
+		ctx.register_handler(entity, this.changed_handler.into());
 
-                ctx.update_theme_by_state(entity);
+		// register name
+		if let Some(name) = this.name {
+		    ctx.register_property("name", entity, name);
+		}
 
-                // register event handlers
-                for handler in this.event_handlers {
-                    ctx.register_handler(entity, handler);
-                }
+		for child in this.children {
+		    ctx.append_child(entity, child);
+		}
 
-                ctx.register_handler(entity, this.changed_handler.into());
+		entity
+	    }
 
-                // register name
-                if let Some(name) = this.name {
-                    ctx.register_property("name", entity, name);
-                }
+	    fn child(mut self, child: Entity) -> Self {
+		self.children.push(child);
+		self
+	    }
 
-                for child in this.children {
-                    ctx.append_child(entity, child);
-                }
+	    fn insert_changed_handler<H: Fn(&mut StatesContext, Entity) + 'static>(mut self, key: impl Into<String>, handler: Rc<H>) -> Self {
+		let key = key.into();
+		if let Filter::List(filter) = &mut self.on_changed_filter {
+		    filter.push(key.clone());
+		} else {
+		    self.on_changed_filter = Filter::List(vec![key.clone()]);
+		}
+		self.changed_handler.handlers.insert(key, handler);
+		self
+	    }
 
-                entity
-            }
-        }
+	    fn insert_handler(mut self, handler: impl Into<Rc<dyn EventHandler>>) -> Self {
+		self.event_handlers.push(handler.into());
+		self
+	    }
+
+	    /// Creates a new widget.
+	    #[inline]
+	    fn new() -> Self {
+		$widget {
+		    event_handlers: vec![],
+		    enabled: true,
+		    opacity: 1.,
+		    clip: false,
+		    $(
+			$(
+			    $property: None,
+			)*
+		    )*
+		    children: vec![],
+		    ..Default::default()
+		}
+	    }
+	}
     };
 }
 

--- a/orbtk_core/src/properties/mod.rs
+++ b/orbtk_core/src/properties/mod.rs
@@ -32,7 +32,7 @@ where
 }
 
 /// Used to build or share a property.
-#[derive(PartialEq, Debug)]
+#[derive(Debug, PartialEq)]
 pub enum PropertySource<P: Component + Debug> {
     Source(Entity),
     KeySource(String, Entity),
@@ -88,8 +88,11 @@ into_property_source!(PathBuf);
 // Implementation of PropertySource for utils types
 into_property_source!(utils::Alignment: &str);
 into_property_source!(utils::Brush: &str, utils::Color, utils::Value);
+into_property_source!(utils::Constraint: utils::ConstraintBuilder);
+into_property_source!(utils::Filter: &str, String, Vec<String>, Vec<&str>);
 into_property_source!(utils::Orientation: &str);
 into_property_source!(utils::Point: f64, i32, (i32, i32), (f64, f64));
+into_property_source!(utils::SelectionMode: &str);
 into_property_source!(utils::Size: f64, i32, (i32, i32), (f64, f64));
 into_property_source!(
     utils::Rectangle: (i32, i32, i32, i32),
@@ -105,10 +108,8 @@ into_property_source!(
     (f64, f64, f64, f64),
     utils::Value
 );
-into_property_source!(utils::SelectionMode: &str);
 into_property_source!(utils::Visibility: &str);
 into_property_source!(Vec<String>);
-into_property_source!(utils::Filter: &str, String, Vec<String>, Vec<&str>);
 
 // Implementation of css types
 into_property_source!(theming::Selector: &str, String);
@@ -119,11 +120,10 @@ into_property_source!(render::Image: &str, String, (u32, u32, Vec<u32>));
 
 // Implementation of custom property types
 into_property_source!(Blocks: BlocksBuilder, &str, String);
-into_property_source!(utils::Constraint: utils::ConstraintBuilder);
 into_property_source!(DefaultRenderPipeline);
+into_property_source!(FocusState);
+into_property_source!(KeyboardState);
 into_property_source!(ScrollViewerMode: (&str, &str));
 into_property_source!(SelectedEntities: HashSet<Entity>);
 into_property_source!(SelectedIndices: HashSet<usize>);
 into_property_source!(TextSelection: (usize, usize));
-into_property_source!(FocusState);
-into_property_source!(KeyboardState);

--- a/orbtk_core/src/systems/init_system.rs
+++ b/orbtk_core/src/systems/init_system.rs
@@ -84,7 +84,7 @@ pub fn print_tree(entity: Entity, depth: usize, ecm: &mut EntityComponentManager
     };
 
     crate::shell::CONSOLE.log(format!(
-        "{}{} (entity: {}{})",
+        "{}{} (entity: {}, {})",
         "| ".repeat(depth),
         name,
         entity.0,

--- a/orbtk_widgets/src/behaviors/mouse_behavior.rs
+++ b/orbtk_widgets/src/behaviors/mouse_behavior.rs
@@ -70,7 +70,7 @@ widget!(
     /// The `MouseBehavior` widget will take care to handle the actions,
     /// that should be triggered if the mouse pressed event is triggered.
     ///
-    /// **style:** `check-box`
+    /// **style:** `check_box`
     MouseBehavior<MouseBehaviorState>: MouseHandler {
         /// Sets or shares the target of the behavior.
         target: u32,

--- a/orbtk_widgets/src/behaviors/selection_behavior.rs
+++ b/orbtk_widgets/src/behaviors/selection_behavior.rs
@@ -41,7 +41,7 @@ widget!(
     /// The `SelectionBehavior` widget will take care to handle the actions,
     /// that should be triggered if text regions are marked or selected.
     ///
-    /// **style:** `check-box`
+    /// **style:** `check_box`
     SelectionBehavior<SelectionBehaviorState>: MouseHandler {
         /// Sets or shares the target of the behavior.
         target: u32,

--- a/orbtk_widgets/src/items_widget.rs
+++ b/orbtk_widgets/src/items_widget.rs
@@ -45,7 +45,7 @@ impl State for ItemsWidgetState {
 widget!(
     /// The `ItemsWidget` is a simple no interactive items drawer widget.
     ///
-    /// **style:** `items-widget`
+    /// **style:** `items_widget`
     ItemsWidget<ItemsWidgetState> {
         /// Sets or shares the background property.
         background: Brush,


### PR DESCRIPTION
# Context:
This PR will enhances compile capabilities of `showcase` example beside some minor typo fixes.

* showcase: cargo run --release --example showcase --features debug,log
* init_system: fix print format, separating entity and style properties
* typo fixes ind documentation strings
* some sorting and lexigraphically ordering

## Contribution checklist:
- [ ] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [ ] Add unit tests if possible
- [x] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter
