### PR TITLE
Fix slider thumb position update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add new popup code (version 2: new placement and offset properties)
 * Add `bundled` feature
 * Rename `resizeable` to `resizable`
+* Fix thumb position not updating when window is resized 
 
 ### 0.3.1-alpha3
 

--- a/orbtk/examples/popup.rs
+++ b/orbtk/examples/popup.rs
@@ -339,7 +339,7 @@ fn main() {
                 .title("OrbTk - Popup example")
                 .position((100.0, 100.0))
                 .size(680, 690.0)
-                .resizeable(true)
+                .resizable(true)
                 .child(MainView::new().build(ctx))
                 .build(ctx)
         })


### PR DESCRIPTION
# Context:
This pull request fixes #468, where the thumb position on the slider would not update to reflect a resize.

![Peek 2022-01-01 16-56](https://user-images.githubusercontent.com/23250792/147844863-52f88a51-f1c3-44a9-9b70-f6cb9407f2b0.gif)

## Contribution checklist:
- [x] Add [documentation](https://doc.rust-lang.org/1.7.0/book/documentation.html) to all public structs, traits and functions.
- [x] Add unit tests if possible
- [x] Describe the major change(s) in the CHANGELOG.MD
- [x] Run `cargo fmt` to make the formatting consistent across the codebase
- [x] Run `cargo clippy` to check with the linter

Off topic: It would be nice if tests could be written for widgets, but I do not think that exists yet