### PR TITLE
fix ImageWidget examples

### DIFF
--- a/orbtk_widgets/src/image_widget.rs
+++ b/orbtk_widgets/src/image_widget.rs
@@ -8,9 +8,9 @@ widget!(
         /// Sets or shares the image property.
         ///
         /// Set image property:
-        /// * &str: `Image::new().image("path/to/image.png").build(xt)`
-        /// * String: `Image::new().image(String::from()).build(xt)`
-        /// * (width: u32, height: u32, data: Vec<u32>): `Image::new().image((width, height, vec![0; width * height]));`
+        /// * &str: `ImageWidget::new().image("path/to/image.png").build(xt)`
+        /// * String: `ImageWidget::new().image(String::from()).build(xt)`
+        /// * (width: u32, height: u32, data: Vec<u32>): `ImageWidget::new().image((width, height, vec![0; width * height]));`
         image: Image
     }
 );


### PR DESCRIPTION
Fix examples to work. It's `ImageWidget::new()` that doesn't require arguments while `Image::new()` does. The two may have been interchanged.

![bug](https://user-images.githubusercontent.com/77566475/151711647-cdc1f81b-42a2-4b66-98a4-917024f7a4cb.png)